### PR TITLE
StW Event Flags & Theater impovements

### DIFF
--- a/index.js
+++ b/index.js
@@ -694,6 +694,73 @@ express.get("/fortnite/api/calendar/v1/timeline", async (req, res) => {
 		})
 	}
 
+	if (seasondata.season == 6) {
+		activeEvents.push(
+		{
+			"eventType": "EventFlag.Fortnitemares",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		},
+		{
+			"eventType": "EventFlag.FortnitemaresPhase1",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		},
+		{
+			"eventType": "EventFlag.FortnitemaresPhase2",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		})
+	}
+
+	if (seasondata.season == 7) {
+		activeEvents.push(
+		{
+			"eventType": "EventFlag.Frostnite",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		})
+	}
+
+	if (seasondata.season == 8) {
+		activeEvents.push(
+		{
+			"eventType": "EventFlag.Spring2019",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		},
+		{
+			"eventType": "EventFlag.Spring2019.Phase1",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		},
+		{
+			"eventType": "EventFlag.Spring2019.Phase2",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		})
+	}
+
+
+	if (seasondata.season == 9) {
+		activeEvents.push(
+		{
+			"eventType": "EventFlag.Season9",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		},
+		{
+			"eventType": "EventFlag.Season9.Phase1",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		},
+		{
+			"eventType": "EventFlag.Season9.Phase2",
+			"activeUntil": "9999-01-01T00:00:00.000Z",
+			"activeSince": "2020-01-01T00:00:00.000Z"
+		})
+	}
+
     res.json({
         "channels": {
             "client-matchmaking": {

--- a/responses/worldstw.json
+++ b/responses/worldstw.json
@@ -1,11 +1,43 @@
 {
   "theaters": [
     {
-      "displayName": "Stonewood",
+      "displayName": {
+        "de":"Steinwald",
+        "ru":"Камнелесье",
+        "ko":"스톤우드",
+        "zh-hant":"荒木石林",
+        "pt-br":"Floresta Pétrea",
+        "en":"Stonewood",
+        "it":"Pietralegno",
+        "fr":"Fontainebois",
+        "zh-cn":"荒木石林",
+        "es":"Bosque Pedregoso",
+        "ar":"ستون وود",
+        "ja":"ストーンウッド",
+        "pl":"Kamienny Las",
+        "es-419":"Bosque Pedregoso",
+        "tr":"Taşlıorman"
+      },
       "uniqueId": "33A2311D4AE64B361CCE27BC9F313C8B",
       "theaterSlot": 0,
       "bIsTestTheater": false,
-      "description": "Start here.  Challenging enemies and rewarding gameplay.",
+      "description": {
+        "de":"Fange von hier aus an.  Herausfordernde Gegner und motivierendes Gameplay.",
+        "ru":"Начните здесь. Опасные враги и достойные награды.",
+        "ko":"최초 시작 지점입니다. 적에게 도전하고 보상을 받으세요.",
+        "zh-hant":"在此開始。難纏的敵人和獎勵多多的遊戲。",
+        "pt-br":"Comece aqui. Inimigos desafiadores e jogabilidade recompensadora.",
+        "en":"Start here.  Challenging enemies and rewarding gameplay.",
+        "it":"Inizia qui.  Nemici impegnativi e meccaniche di gioco appaganti.",
+        "fr":"Commencez ici. Des ennemis difficiles mais une expérience gratifiante.",
+        "zh-cn":"在此开始。难缠的敌人和奖励多多的游戏。",
+        "es":"Empieza aquí.  Enemigos peligrosos y juego gratificante.",
+        "ar":"ابدأ من هنا. أعداءٌ أقوياء ونظام لعبٍ مُربِح.",
+        "ja":"さあ始めよう。手強い敵と報酬が待っている。",
+        "pl":"Zacznij tutaj. Wrogowie stanowiący wyzwanie oraz satysfakcjonująca rozgrywka.",
+        "es-419":"Comienza aquí.  Enemigos difíciles y experiencia de juego gratificante.",
+        "tr":"Buradan başla. Zorlayıcı rakipler ve ödüllendirici oynanış."
+      },
       "runtimeInfo": {
         "theaterType": "Standard",
         "theaterTags": {
@@ -19,8 +51,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "None",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -31,8 +61,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "None",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -294,8 +322,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L3.OutpostQuest_T1_L3'",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -311,8 +337,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -345,8 +369,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_1_D4.StonewoodQuest_Filler_1_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -370,8 +392,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -395,8 +415,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_1_D2.StonewoodQuest_Filler_1_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -425,8 +443,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -450,8 +466,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -475,8 +489,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -500,8 +512,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -525,8 +535,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L6.OutpostQuest_T1_L6'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -535,7 +543,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_LaunchRocket_D5.StonewoodQuest_LaunchRocket_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -563,8 +570,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -588,8 +593,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -613,8 +616,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -643,8 +644,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_2_D5.StonewoodQuest_Filler_2_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -668,8 +667,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -698,8 +695,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -728,8 +723,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -753,8 +746,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/ReactiveQuests/ReactiveQuest_DistressCalls.ReactiveQuest_DistressCalls'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -778,8 +769,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -788,14 +777,12 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/ReactiveQuests/ReactiveQuest_DistressCalls.ReactiveQuest_DistressCalls'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_2_D4.StonewoodQuest_Filler_2_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -823,8 +810,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -853,8 +838,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -883,8 +866,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -893,7 +874,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/ReactiveQuests/ReactiveQuest_MedicalSupplies.ReactiveQuest_MedicalSupplies'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -921,8 +901,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -931,7 +909,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_2_D5.StonewoodQuest_Filler_2_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -959,8 +936,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1005,8 +980,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1035,8 +1008,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1081,8 +1052,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1106,8 +1075,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1131,8 +1098,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1156,8 +1121,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_LaunchBalloon_D1.StonewoodQuest_LaunchBalloon_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1186,8 +1149,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_RetrieveData_D1.StonewoodQuest_RetrieveData_D1'",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_1_D2.StonewoodQuest_Filler_1_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1196,7 +1157,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_RetrieveData_D1.StonewoodQuest_RetrieveData_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -1224,8 +1184,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/ReactiveQuests/ReactiveQuest_Transmitters.ReactiveQuest_Transmitters'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1249,8 +1207,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1274,8 +1230,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1299,8 +1253,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1324,8 +1276,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1349,8 +1299,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1374,8 +1322,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L3.OutpostQuest_T1_L3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1384,14 +1330,12 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Daily/Daily_High_Priority.Daily_High_Priority'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Side_1_D4.StonewoodQuest_Side_1_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -1414,8 +1358,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/ReactiveQuests/ReactiveQuest_DistressCalls.ReactiveQuest_DistressCalls'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1424,7 +1366,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_1_D3.StonewoodQuest_Filler_1_D3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -1452,8 +1393,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Challenges/Challenge_WeaponUpgrade_1.Challenge_WeaponUpgrade_1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1462,14 +1401,12 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_1_D2.StonewoodQuest_Filler_1_D2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_TreasuredFriends.StonewoodQuest_TreasuredFriends'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -1497,8 +1434,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1522,8 +1457,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1547,8 +1480,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1572,8 +1503,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1602,8 +1531,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1627,8 +1554,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1652,8 +1577,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1690,8 +1613,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L6.OutpostQuest_T1_L6'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1715,8 +1636,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_Filler_2_D4.StonewoodQuest_Filler_2_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1740,8 +1659,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1765,8 +1682,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1790,8 +1705,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1815,8 +1728,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1840,8 +1751,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1865,8 +1774,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1890,8 +1797,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1915,8 +1820,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1940,8 +1843,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1965,8 +1866,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -1990,8 +1889,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2015,8 +1912,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2040,8 +1935,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2065,8 +1958,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_LaunchBalloon_D1.StonewoodQuest_LaunchBalloon_D1'",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Onboarding/HomebaseQuest_SlotEMTWorker.HomebaseQuest_SlotEMTWorker'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2075,7 +1966,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_LaunchBalloon_D1.StonewoodQuest_LaunchBalloon_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -2103,8 +1993,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2128,8 +2016,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Hero/HeroQuest_ConstructorLeadership.HeroQuest_ConstructorLeadership'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2153,8 +2039,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2163,70 +2047,60 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L1.OutpostQuest_T1_L1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L2.OutpostQuest_T1_L2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L3.OutpostQuest_T1_L3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L4.OutpostQuest_T1_L4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L5.OutpostQuest_T1_L5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L6.OutpostQuest_T1_L6'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L7.OutpostQuest_T1_L7'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L8.OutpostQuest_T1_L8'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L9.OutpostQuest_T1_L9'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L10.OutpostQuest_T1_L10'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -2262,8 +2136,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_CloseGate_D1.StonewoodQuest_CloseGate_D1'",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2272,7 +2144,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_CloseGate_D1.StonewoodQuest_CloseGate_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -2300,8 +2171,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2325,8 +2194,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2350,8 +2217,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2375,8 +2240,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2400,8 +2263,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2425,8 +2286,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2450,8 +2309,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2475,8 +2332,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2500,8 +2355,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2525,8 +2378,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2550,8 +2401,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2575,8 +2424,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2600,8 +2447,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2625,8 +2470,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2650,8 +2493,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2675,8 +2516,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2700,8 +2539,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2725,8 +2562,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2750,8 +2585,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2775,8 +2608,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2800,8 +2631,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2830,8 +2659,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Hero/HeroQuest_ConstructorLeadership.HeroQuest_ConstructorLeadership'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2855,8 +2682,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Hero/HeroQuest_ConstructorLeadership.HeroQuest_ConstructorLeadership'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2880,8 +2705,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2905,8 +2728,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Hero/HeroQuest_ConstructorLeadership.HeroQuest_ConstructorLeadership'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2930,8 +2751,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L1.OutpostQuest_T1_L1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2955,8 +2774,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -2980,8 +2797,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3005,8 +2820,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3030,8 +2843,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3055,8 +2866,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3080,8 +2889,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3105,8 +2912,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3130,8 +2935,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3198,8 +3001,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L4.OutpostQuest_T1_L4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3252,8 +3053,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L4.OutpostQuest_T1_L4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3354,8 +3153,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3406,8 +3203,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L2.OutpostQuest_T1_L2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3469,8 +3264,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L5.OutpostQuest_T1_L5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3524,8 +3317,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L5.OutpostQuest_T1_L5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3578,8 +3369,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/ReactiveQuests/ReactiveQuest_DistressCalls.ReactiveQuest_DistressCalls'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3631,8 +3420,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L3.OutpostQuest_T1_L3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3683,8 +3470,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T1_L1.OutpostQuest_T1_L1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3712,8 +3497,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3741,8 +3524,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -3753,11 +3534,43 @@
       ]
     },
     {
-      "displayName": "Plankerton",
+      "displayName": {
+        "de":"Plankerton",
+        "ru":"Планкертон",
+        "ko":"플랭커튼",
+        "zh-hant":"普蘭克頓",
+        "pt-br":"Plankerton",
+        "en":"Plankerton",
+        "it":"Tavolaccia",
+        "fr":"Villeplanche",
+        "zh-cn":"普兰克顿",
+        "es":"Villatablón",
+        "ar":"بلانكرتون",
+        "ja":"プランカートン",
+        "pl":"Deskogród",
+        "es-419":"Ciudad Tablón",
+        "tr":"Kalaslıevler"
+      },
       "uniqueId": "D477605B4FA48648107B649CE97FCF27",
       "theaterSlot": 0,
       "bIsTestTheater": false,
-      "description": "Tougher enemies and greater rewards await in Plankerton.",
+      "description": {
+        "de":"In Plankerton erwarten dich härtere Gegner, aber auch größere Belohnungen.",
+        "ru":"В Планкертоне враги опаснее прежних, но и награды лучше.",
+        "ko":"플랭커튼에서 강력한 적과 싸우고 더 좋은 보상을 받으세요.",
+        "zh-hant":"普蘭克頓有更強力的敵人，也有更豐厚的獎勵。",
+        "pt-br":"Inimigos mais difíceis e recompensas melhores aguardam você em Plankerton.",
+        "en":"Tougher enemies and greater rewards await in Plankerton.",
+        "it":"Nemici più impegnativi e ricompense migliori ti attendono a Tavolaccia.",
+        "fr":"Des ennemis plus coriaces et des récompenses supérieures vous attendent à Villeplanche.",
+        "zh-cn":"普兰克顿有更强力的敌人，也有更丰厚的奖励。",
+        "es":"Enemigos más duros y recompensas más jugosas esperan en Villatablón.",
+        "ar":"ستجد في انتظارك في بلانكرتون أعداء أشرس ومكافآت أكبر.",
+        "ja":"プランカートンで、より強力な敵とすばらしい報酬があなたを待っている。",
+        "pl":"W Deskogrodzie czekają trudniejsi wrogowie i lepsze nagrody.",
+        "es-419":"Esperan enemigos más fuertes y recompensas más grandes en Ciudad Tablón.",
+        "tr":"Daha güçlü rakipler ve daha büyük ödüller Kalaslıevler'de bekliyor."
+      },
       "runtimeInfo": {
         "theaterType": "Standard",
         "theaterTags": {
@@ -3771,8 +3584,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "None",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -3783,8 +3594,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_LaunchRocket_D5.StonewoodQuest_LaunchRocket_D5'",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -4046,8 +3855,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "FortQuestItemDefinition'/Game/Quests/Stonewood/StonewoodQuest_LaunchRocket_D5.StonewoodQuest_LaunchRocket_D5'",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -4063,8 +3870,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D1.PlankertonQuest_Filler_1_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4088,8 +3893,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D1.PlankertonQuest_Filler_2_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4113,8 +3916,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4123,7 +3924,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D1.PlankertonQuest_Filler_3_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4151,8 +3951,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4161,7 +3959,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D1.PlankertonQuest_Filler_1_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4189,8 +3986,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D1.PlankertonQuest_Filler_3_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4214,8 +4009,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4239,8 +4032,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4264,8 +4055,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_4_D1.PlankertonQuest_Filler_4_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4289,8 +4078,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D2.PlankertonQuest_Filler_1_D2'",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4299,7 +4086,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D2.PlankertonQuest_Filler_1_D2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4327,8 +4113,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4337,7 +4121,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D5.PlankertonQuest_Filler_2_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4365,8 +4148,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4390,8 +4171,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4415,8 +4194,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4440,8 +4217,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4465,8 +4240,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4475,14 +4248,12 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D2.PlankertonQuest_Filler_2_D2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_4_D2.PlankertonQuest_Filler_4_D2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4510,8 +4281,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D2.PlankertonQuest_Filler_2_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4535,8 +4304,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_4_D2.PlankertonQuest_Filler_4_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4560,8 +4327,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4570,70 +4335,60 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L1.OutpostQuest_T2_L1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L2.OutpostQuest_T2_L2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L3.OutpostQuest_T2_L3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L4.OutpostQuest_T2_L4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L5.OutpostQuest_T2_L5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L6.OutpostQuest_T2_L6'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L7.OutpostQuest_T2_L7'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L8.OutpostQuest_T2_L8'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L9.OutpostQuest_T2_L9'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L10.OutpostQuest_T2_L10'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4669,8 +4424,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4679,7 +4432,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D5.PlankertonQuest_Filler_1_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4707,8 +4459,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D4.PlankertonQuest_Filler_1_D4'",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4717,7 +4467,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D4.PlankertonQuest_Filler_1_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4745,8 +4494,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4755,7 +4502,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D5.PlankertonQuest_Filler_3_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4783,8 +4529,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_4_D4.PlankertonQuest_Filler_4_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4808,8 +4552,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4818,7 +4560,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_5_D4.PlankertonQuest_Filler_5_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -4846,8 +4587,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4871,8 +4610,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D2.PlankertonQuest_Filler_2_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4896,8 +4633,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4921,8 +4656,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D2.PlankertonQuest_Filler_3_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4946,8 +4679,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4971,8 +4702,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_4_D3.PlankertonQuest_Filler_4_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -4996,8 +4725,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5006,7 +4733,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_6_D4.PlankertonQuest_Filler_6_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5034,8 +4760,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D3.PlankertonQuest_Filler_3_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5059,8 +4783,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5069,7 +4791,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_8_D4.PlankertonQuest_Filler_8_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5097,8 +4818,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D4.PlankertonQuest_Filler_3_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5122,8 +4841,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D4.PlankertonQuest_Filler_2_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5147,8 +4864,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5172,8 +4887,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5182,7 +4895,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D1.PlankertonQuest_Filler_2_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5210,8 +4922,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5220,14 +4930,12 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_5_D5.PlankertonQuest_Filler_5_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_10_D5.PlankertonQuest_Filler_10_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5255,8 +4963,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "FortQuestItemDefinition'/Game/Quests/ReactiveQuests/ReactiveQuest_MasterServers.ReactiveQuest_MasterServers'",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5265,7 +4971,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/ReactiveQuests/ReactiveQuest_MasterServers.ReactiveQuest_MasterServers'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5293,8 +4998,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L6.OutpostQuest_T2_L6'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5303,7 +5006,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_LaunchRocket_D5.PlankertonQuest_LaunchRocket_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5331,8 +5033,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5341,7 +5041,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_7_D3.PlankertonQuest_Filler_7_D3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5369,8 +5068,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5379,7 +5076,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_5_D3.PlankertonQuest_Filler_5_D3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5407,8 +5103,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D5.PlankertonQuest_Filler_2_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5432,8 +5126,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5442,7 +5134,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_9_D5.PlankertonQuest_Filler_9_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5470,8 +5161,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5495,8 +5184,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5505,7 +5192,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_9_D4.PlankertonQuest_Filler_9_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5533,8 +5219,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D5.PlankertonQuest_Filler_1_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5563,8 +5247,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5588,8 +5270,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5613,8 +5293,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5638,8 +5316,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5663,8 +5339,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5688,8 +5362,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5713,8 +5385,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5738,8 +5408,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5763,8 +5431,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D5.PlankertonQuest_Filler_3_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5788,8 +5454,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5813,8 +5477,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5838,8 +5500,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5863,8 +5523,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5888,8 +5546,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5913,8 +5569,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5923,7 +5577,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_9_D5.PlankertonQuest_Filler_9_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -5951,8 +5604,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -5976,8 +5627,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6001,8 +5650,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6026,8 +5673,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6051,8 +5696,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6076,8 +5719,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6101,8 +5742,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6126,8 +5765,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6151,8 +5788,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6176,8 +5811,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6201,8 +5834,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6226,8 +5857,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6251,8 +5880,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6276,8 +5903,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6301,8 +5926,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6326,8 +5949,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6351,8 +5972,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6376,8 +5995,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6401,8 +6018,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6426,8 +6041,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6451,8 +6064,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6476,8 +6087,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6501,8 +6110,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6526,8 +6133,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6551,8 +6156,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6576,8 +6179,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6601,8 +6202,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6626,8 +6225,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6651,8 +6248,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6676,8 +6271,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6701,8 +6294,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6726,8 +6317,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6751,8 +6340,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6776,8 +6363,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6801,8 +6386,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6826,8 +6409,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6851,8 +6432,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6876,8 +6455,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6901,8 +6478,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6926,8 +6501,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6951,8 +6524,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -6976,8 +6547,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D2.PlankertonQuest_Filler_3_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7001,8 +6570,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7026,8 +6593,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7051,8 +6616,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7076,8 +6639,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7101,8 +6662,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7126,8 +6685,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7151,8 +6708,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7176,8 +6731,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7201,8 +6754,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7226,8 +6777,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7251,8 +6800,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7276,8 +6823,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7301,8 +6846,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7326,8 +6869,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7351,8 +6892,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7376,8 +6915,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7401,8 +6938,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7426,8 +6961,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7451,8 +6984,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7476,8 +7007,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7501,8 +7030,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7526,8 +7053,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7551,8 +7076,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7576,8 +7099,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7601,8 +7122,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7626,8 +7145,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7651,8 +7168,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7676,8 +7191,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D1.PlankertonQuest_Filler_2_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7701,8 +7214,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7726,8 +7237,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7736,7 +7245,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_4_D1.PlankertonQuest_Filler_4_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -7764,8 +7272,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7789,8 +7295,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D1.PlankertonQuest_Filler_3_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7814,8 +7318,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7839,8 +7341,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D2.PlankertonQuest_Filler_1_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7864,8 +7364,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7889,8 +7387,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7914,8 +7410,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7939,8 +7433,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7964,8 +7456,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -7989,8 +7479,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8014,8 +7502,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D3.PlankertonQuest_Filler_2_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8039,8 +7525,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D3.PlankertonQuest_Filler_2_D3'",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D3.PlankertonQuest_Filler_1_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8049,7 +7533,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D3.PlankertonQuest_Filler_2_D3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -8077,8 +7560,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8102,8 +7583,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8127,8 +7606,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8152,8 +7629,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8177,8 +7652,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D3.PlankertonQuest_Filler_2_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8202,8 +7675,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8227,8 +7698,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8252,8 +7721,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8277,8 +7744,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D3.PlankertonQuest_Filler_3_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8302,8 +7767,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8312,7 +7775,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_6_D4.PlankertonQuest_Filler_6_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -8340,8 +7802,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D4.PlankertonQuest_Filler_2_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8365,8 +7825,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8390,8 +7848,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8415,8 +7871,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8440,8 +7894,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8465,8 +7917,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_1_D4.PlankertonQuest_Filler_1_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8490,8 +7940,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_3_D4.PlankertonQuest_Filler_3_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8515,8 +7963,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8540,8 +7986,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8565,8 +8009,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8590,8 +8032,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8615,8 +8055,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D5.PlankertonQuest_Filler_2_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8640,8 +8078,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L1.OutpostQuest_T2_L1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8650,14 +8086,12 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_6_D3.PlankertonQuest_Filler_6_D3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Daily/Daily_High_Priority.Daily_High_Priority'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -8680,8 +8114,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8705,8 +8137,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8791,8 +8221,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L1.OutpostQuest_T2_L1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -8927,8 +8355,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9010,8 +8436,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L2.OutpostQuest_T2_L2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9101,8 +8525,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L5.OutpostQuest_T2_L5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9130,8 +8552,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9217,8 +8637,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L4.OutpostQuest_T2_L4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9280,8 +8698,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D2.PlankertonQuest_Filler_2_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9363,8 +8779,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T2_L3.OutpostQuest_T2_L3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9434,8 +8848,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D5.PlankertonQuest_Filler_2_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9489,8 +8901,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_2_D1.CannyValleyQuest_Filler_2_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9552,8 +8962,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D3.PlankertonQuest_Filler_2_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9619,8 +9027,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_Filler_2_D4.PlankertonQuest_Filler_2_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9648,8 +9054,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9660,11 +9064,43 @@
       ]
     },
     {
-      "displayName": "Canny Valley",
+      "displayName": {
+        "de":"Bru-Tal",
+        "ru":"Вещая долина",
+        "ko":"캐니 밸리",
+        "zh-hant":"坎尼山谷",
+        "pt-br":"Canny Valley",
+        "en":"Canny Valley",
+        "it":"Vallarguta",
+        "fr":"Morne-la-Vallée",
+        "zh-cn":"坎尼山谷",
+        "es":"Valle Latoso",
+        "ar":"وادي الدهاة",
+        "ja":"キャニー・バレー",
+        "pl":"Dolina Samowitości",
+        "es-419":"Valle Latoso",
+        "tr":"Tekinli Vadi"
+      },
       "uniqueId": "E6ECBD064B153234656CB4BDE6743870",
       "theaterSlot": 0,
       "bIsTestTheater": false,
-      "description": "Even tougher enemies, with even better rewards.",
+      "description": {
+        "de":"Noch stärkere Gegner mit noch besseren Belohnungen.",
+        "ru":"Ещё более крутые враги с более щедрыми наградами.",
+        "ko":"더 강력한 적과 더 멋진 보상이 기다리고 있습니다.",
+        "zh-hant":"越是難纏的敵人，獎勵就越豐厚。",
+        "pt-br":"Inimigos ainda mais difíceis, recompensas ainda melhores.",
+        "en":"Even tougher enemies, with even better rewards.",
+        "it":"Nemici ancora più impegnativi, con ricompense ancora migliori.",
+        "fr":"Des ennemis encore plus coriaces, avec des récompenses encore meilleures.",
+        "zh-cn":"越是难缠的敌人，奖励就越丰厚。",
+        "es":"Enemigos aún más duros. Recompensas aún mejores.",
+        "ar":"كلما ازدادت شراسة الأعداء، أصبحت المكافآت أفضل.",
+        "ja":"敵が強くなるが、報酬も良くなる。",
+        "pl":"Jeszcze silniejsi wrogowie, jeszcze lepsze nagrody.",
+        "es-419":"Enemigos aún más fuertes, con recompensas todavía mejores.",
+        "tr":"Çok daha güçlü rakipler, çok daha iyi ödüller."
+      },
       "runtimeInfo": {
         "theaterType": "Standard",
         "theaterTags": {
@@ -9678,8 +9114,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "None",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -9690,8 +9124,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_LaunchRocket_D5.PlankertonQuest_LaunchRocket_D5'",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -9953,8 +9385,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "FortQuestItemDefinition'/Game/Quests/Plankerton/PlankertonQuest_LaunchRocket_D5.PlankertonQuest_LaunchRocket_D5'",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -9970,8 +9400,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -9995,8 +9423,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10020,8 +9446,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10045,8 +9469,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10070,8 +9492,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10095,8 +9515,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10120,8 +9538,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10145,8 +9561,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L1.OutpostQuest_T3_L1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10155,14 +9569,12 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_1_D1.CannyValleyQuest_Filler_1_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Daily/Daily_High_Priority.Daily_High_Priority'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -10185,8 +9597,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_4_D2.CannyValleyQuest_Filler_4_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10195,7 +9605,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Side_1_D2.CannyValleyQuest_Side_1_D2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -10223,8 +9632,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10233,7 +9640,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_1_D2.CannyValleyQuest_Filler_1_D2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -10261,8 +9667,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10286,8 +9690,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_3_D1.CannyValleyQuest_Filler_3_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10296,7 +9698,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_4_D1.CannyValleyQuest_Filler_4_D1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -10324,8 +9725,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_4_D1.CannyValleyQuest_Filler_4_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10349,8 +9748,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_2_D1.CannyValleyQuest_Filler_2_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10374,8 +9771,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10399,8 +9794,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10424,8 +9817,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10434,70 +9825,60 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L1.OutpostQuest_T3_L1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L2.OutpostQuest_T3_L2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L3.OutpostQuest_T3_L3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L4.OutpostQuest_T3_L4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L5.OutpostQuest_T3_L5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L6.OutpostQuest_T3_L6'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L7.OutpostQuest_T3_L7'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L8.OutpostQuest_T3_L8'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L9.OutpostQuest_T3_L9'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L10.OutpostQuest_T3_L10'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -10533,8 +9914,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10558,8 +9937,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10583,8 +9960,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_2_D2.CannyValleyQuest_Filler_2_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10608,8 +9983,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10633,8 +10006,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10658,8 +10029,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10683,8 +10052,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_5_D4.CannyValleyQuest_Filler_5_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10708,8 +10075,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_6_D4.CannyValleyQuest_Filler_6_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10718,7 +10083,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Side_1_D4.CannyValleyQuest_Side_1_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -10746,8 +10110,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_3_D2.CannyValleyQuest_Filler_3_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10756,7 +10118,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_4_D2.CannyValleyQuest_Filler_4_D2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -10784,8 +10145,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10809,8 +10168,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_1_D2.CannyValleyQuest_Filler_1_D2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10834,8 +10191,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10859,8 +10214,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10884,8 +10237,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_3_D4.CannyValleyQuest_Filler_3_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10894,7 +10245,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_5_D4.CannyValleyQuest_Filler_5_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -10922,8 +10272,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10947,8 +10295,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10972,8 +10318,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -10997,8 +10341,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11022,8 +10364,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11047,8 +10387,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11072,8 +10410,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11097,8 +10433,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11122,8 +10456,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11147,8 +10479,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11172,8 +10502,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11197,8 +10525,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11222,8 +10548,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11247,8 +10571,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_1_D1.CannyValleyQuest_Filler_1_D1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11272,8 +10594,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11297,8 +10617,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11322,8 +10640,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11347,8 +10663,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11372,8 +10686,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11397,8 +10709,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11422,8 +10732,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11447,8 +10755,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11472,8 +10778,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11497,8 +10801,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11522,8 +10824,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11547,8 +10847,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11572,8 +10870,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11597,8 +10893,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11622,8 +10916,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11647,8 +10939,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11672,8 +10962,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11697,8 +10985,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11722,8 +11008,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11747,8 +11031,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11772,8 +11054,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11797,8 +11077,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_LaunchRocket_D5.CannyValleyQuest_LaunchRocket_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11822,8 +11100,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_1_D5.CannyValleyQuest_Filler_1_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11852,8 +11128,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L6.OutpostQuest_T3_L6'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11862,7 +11136,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_LaunchRocket_D5.CannyValleyQuest_LaunchRocket_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -11890,8 +11163,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11915,8 +11186,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11940,8 +11209,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11965,8 +11232,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_4_D5.CannyValleyQuest_Filler_4_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -11995,8 +11260,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12020,8 +11283,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12045,8 +11306,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12070,8 +11329,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12095,8 +11352,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12120,8 +11375,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12145,8 +11398,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12170,8 +11421,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12195,8 +11444,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12220,8 +11467,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12245,8 +11490,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12270,8 +11513,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12295,8 +11536,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12320,8 +11559,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12345,8 +11582,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12370,8 +11605,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12395,8 +11628,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12420,8 +11651,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12445,8 +11674,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12470,8 +11697,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12495,8 +11720,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12520,8 +11743,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12545,8 +11766,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12570,8 +11789,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12595,8 +11812,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_2_D4.CannyValleyQuest_Filler_2_D4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12605,7 +11820,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_3_D4.CannyValleyQuest_Filler_3_D4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -12633,8 +11847,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12658,8 +11870,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12683,8 +11893,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12708,8 +11916,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_3_D3.CannyValleyQuest_Filler_3_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12718,7 +11924,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_4_D3.CannyValleyQuest_Filler_4_D3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -12746,8 +11951,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12756,7 +11959,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_1_D3.CannyValleyQuest_Filler_1_D3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -12784,8 +11986,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12809,8 +12009,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12834,8 +12032,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_1_D3.CannyValleyQuest_Filler_1_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12844,7 +12040,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_2_D3.CannyValleyQuest_Filler_2_D3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -12872,8 +12067,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_2_D3.CannyValleyQuest_Filler_2_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12897,8 +12090,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12922,8 +12113,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12947,8 +12136,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12972,8 +12159,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -12997,8 +12182,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13022,8 +12205,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13047,8 +12228,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13072,8 +12251,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13097,8 +12274,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13122,8 +12297,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_Filler_4_D3.CannyValleyQuest_Filler_4_D3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13147,8 +12320,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13172,8 +12343,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13197,8 +12366,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13222,8 +12389,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13247,8 +12412,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13272,8 +12435,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13297,8 +12458,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13322,8 +12481,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13347,8 +12504,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13372,8 +12527,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13397,8 +12550,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13422,8 +12573,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13447,8 +12596,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13472,8 +12619,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13497,8 +12642,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13522,8 +12665,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13547,8 +12688,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13572,8 +12711,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13597,8 +12734,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13622,8 +12757,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13647,8 +12780,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13672,8 +12803,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13697,8 +12826,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13722,8 +12849,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13747,8 +12872,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13772,8 +12895,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13797,8 +12918,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13822,8 +12941,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13847,8 +12964,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13872,8 +12987,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13897,8 +13010,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13922,8 +13033,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13947,8 +13056,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13972,8 +13079,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -13997,8 +13102,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14022,8 +13125,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14047,8 +13148,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14072,8 +13171,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14097,8 +13194,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14236,8 +13331,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14329,8 +13422,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L1.OutpostQuest_T3_L1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14424,8 +13515,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L5.OutpostQuest_T3_L5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14453,8 +13542,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14549,8 +13636,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L2.OutpostQuest_T3_L2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14578,8 +13663,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14673,8 +13756,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L4.OutpostQuest_T3_L4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14769,8 +13850,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T3_L3.OutpostQuest_T3_L3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -14781,11 +13860,43 @@
       ]
     },
     {
-      "displayName": "Twine Peaks",
+      "displayName": {
+        "de":"Twine Peaks",
+        "ru":"Линч-Пикс",
+        "ko":"트와인 픽스",
+        "zh-hant":"麻峰",
+        "pt-br":"Twine Peaks",
+        "en":"Twine Peaks",
+        "it":"Montespago",
+        "fr":"Pics Hardis",
+        "zh-cn":"麻峰",
+        "es":"Cumbres Leñosas",
+        "ar":"القمم التوائم",
+        "ja":"トワイン・ピークス",
+        "pl":"Twine Peaks",
+        "es-419":"Picos Trenzados",
+        "tr":"Dikiz Tepeler"
+      },
       "uniqueId": "D9A801C5444D1C74D1B7DAB5C7C12C5B",
       "theaterSlot": 0,
       "bIsTestTheater": false,
-      "description": "Weather alert! These missions will challenge even the best Commanders.",
+      "description": {
+        "de":"Unwetterwarnung! Diese Missionen sind selbst für die besten Kommandanten eine Herausforderung.",
+        "ru":"Гидрометцентр предупреждает! Эти миссии заставят попотеть даже самых лучших командиров.",
+        "ko":"기상 경보! 이곳 미션은 가장 뛰어난 지휘관에게도 쉽지 않을 것입니다.",
+        "zh-hant":"天氣警報！ 即便最優秀的指揮官也會面臨這些任務的重重挑戰。",
+        "pt-br":"Alerta de clima! Essas missões desafiarão até os melhores Comandantes.",
+        "en":"Weather alert! These missions will challenge even the best Commanders.",
+        "it":"Allerta meteo! Queste missioni metteranno alla prova anche i migliori Comandanti.",
+        "fr":"Alerte météo ! Ces missions mettront au défi même les plus accomplis des Commandants.",
+        "zh-cn":"天气警报！即便最优秀的指挥官也会面临这些任务的重重挑战。",
+        "es":"¡Alerta meteorológica! Estas misiones serán un desafío incluso para los mejores comandantes.",
+        "ar":"تنبيه الطقس! ستُمثّل هذه المهمات تحدّيات حتى لأفضل القادة.",
+        "ja":"暴風警報！ トップクラスのコマンダーでも困難なミッションです。",
+        "pl":"Ostrzeżenie o pogodzie! Ta misja stanowi wyzwanie nawet dla najlepszych dowódców.",
+        "es-419":"¡Alerta de mal tiempo! Estas misiones serán un desafío incluso para los mejores comandantes.",
+        "tr":"Hava durumu uyarısı! Bu görevler en iyi Komutanları bile zorlar."
+      },
       "runtimeInfo": {
         "theaterType": "Standard",
         "theaterTags": {
@@ -14799,8 +13910,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "None",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -14811,8 +13920,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_LaunchRocket_D5.CannyValleyQuest_LaunchRocket_D5'",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -15074,8 +14181,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "FortQuestItemDefinition'/Game/Quests/CannyValley/CannyValleyQuest_LaunchRocket_D5.CannyValleyQuest_LaunchRocket_D5'",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -15091,8 +14196,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15116,8 +14219,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15141,8 +14242,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15166,8 +14265,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15191,8 +14288,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15216,8 +14311,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15226,70 +14319,60 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L1.OutpostQuest_T4_L1'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L2.OutpostQuest_T4_L2'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L3.OutpostQuest_T4_L3'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L4.OutpostQuest_T4_L4'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L5.OutpostQuest_T4_L5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L6.OutpostQuest_T4_L6'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L7.OutpostQuest_T4_L7'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L8.OutpostQuest_T4_L8'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L9.OutpostQuest_T4_L9'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
               }
             },
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L10.OutpostQuest_T4_L10'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -15325,8 +14408,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15350,8 +14431,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15375,8 +14454,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15400,8 +14477,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15425,8 +14500,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L1.OutpostQuest_T4_L1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15435,7 +14508,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/Daily/Daily_High_Priority.Daily_High_Priority'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -15458,8 +14530,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15483,8 +14553,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15508,8 +14576,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15533,8 +14599,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15558,8 +14622,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15583,8 +14645,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15608,8 +14668,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15633,8 +14691,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15658,8 +14714,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15683,8 +14737,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15708,8 +14760,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15733,8 +14783,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15758,8 +14806,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15783,8 +14829,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15808,8 +14852,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/TwinePeaks/TwinePeaksQuest_LaunchRocket_D5.TwinePeaksQuest_LaunchRocket_D5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15818,7 +14860,6 @@
           },
           "linkedQuests": [
             {
-              "questDefinition": "FortQuestItemDefinition'/Game/Quests/TwinePeaks/TwinePeaksQuest_LaunchRocket_D5.TwinePeaksQuest_LaunchRocket_D5'",
               "objectiveStatHandle": {
                 "dataTable": "None",
                 "rowName": "None"
@@ -15846,8 +14887,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15871,8 +14910,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15896,8 +14933,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15921,8 +14956,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15946,8 +14979,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15971,8 +15002,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -15996,8 +15025,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16021,8 +15048,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16046,8 +15071,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16071,8 +15094,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16096,8 +15117,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16121,8 +15140,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16146,8 +15163,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16171,8 +15186,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16196,8 +15209,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16221,8 +15232,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16246,8 +15255,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16271,8 +15278,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16296,8 +15301,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16321,8 +15324,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16346,8 +15347,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16371,8 +15370,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16396,8 +15393,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16421,8 +15416,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16446,8 +15439,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16471,8 +15462,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16496,8 +15485,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16521,8 +15508,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16546,8 +15531,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16571,8 +15554,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16596,8 +15577,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16621,8 +15600,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16646,8 +15623,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16671,8 +15646,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16696,8 +15669,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16721,8 +15692,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16746,8 +15715,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16771,8 +15738,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16796,8 +15761,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16821,8 +15784,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16846,8 +15807,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16871,8 +15830,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16896,8 +15853,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16921,8 +15876,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16946,8 +15899,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16971,8 +15922,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -16996,8 +15945,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17021,8 +15968,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17046,8 +15991,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17071,8 +16014,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17096,8 +16037,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17121,8 +16060,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17146,8 +16083,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17171,8 +16106,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17196,8 +16129,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17221,8 +16152,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17246,8 +16175,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17271,8 +16198,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17296,8 +16221,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17321,8 +16244,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17346,8 +16267,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17371,8 +16290,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17396,8 +16313,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17421,8 +16336,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17446,8 +16359,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17471,8 +16382,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17496,8 +16405,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17521,8 +16428,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17546,8 +16451,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17571,8 +16474,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17596,8 +16497,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17621,8 +16520,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17646,8 +16543,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17671,8 +16566,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17696,8 +16589,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17721,8 +16612,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17746,8 +16635,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17771,8 +16658,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17796,8 +16681,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17821,8 +16704,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17846,8 +16727,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17871,8 +16750,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17896,8 +16773,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17921,8 +16796,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17946,8 +16819,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17971,8 +16842,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -17996,8 +16865,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18021,8 +16888,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18046,8 +16911,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18071,8 +16934,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18096,8 +16957,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18121,8 +16980,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18146,8 +17003,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18171,8 +17026,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18196,8 +17049,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18221,8 +17072,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18246,8 +17095,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18271,8 +17118,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18296,8 +17141,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18321,8 +17164,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18346,8 +17187,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18371,8 +17210,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18396,8 +17233,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18421,8 +17256,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18446,8 +17279,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18471,8 +17302,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18496,8 +17325,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18521,8 +17348,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18546,8 +17371,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18571,8 +17394,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18596,8 +17417,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18621,8 +17440,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18646,8 +17463,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18671,8 +17486,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18696,8 +17509,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18798,8 +17609,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L5.OutpostQuest_T4_L5'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18889,8 +17698,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L4.OutpostQuest_T4_L4'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -18918,8 +17725,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -19009,8 +17814,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L3.OutpostQuest_T4_L3'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -19126,8 +17929,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -19155,8 +17956,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -19246,8 +18045,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L1.OutpostQuest_T4_L1'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -19341,8 +18138,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "FortQuestItemDefinition'/Game/Quests/Outpost/OutpostQuest_T4_L2.OutpostQuest_T4_L2'",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -19367,8 +18162,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "None",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -19379,8 +18172,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "None",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -19642,8 +18433,6 @@
           "commanderLevel": 0,
           "personalPowerRating": 0,
           "partyPowerRating": 0,
-          "activeQuestDefinition": "None",
-          "questDefinition": "None",
           "objectiveStatHandle": {
             "dataTable": "None",
             "rowName": "None"
@@ -19659,8 +18448,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"
@@ -19704,8 +18491,6 @@
             "commanderLevel": 0,
             "personalPowerRating": 0,
             "partyPowerRating": 0,
-            "activeQuestDefinition": "None",
-            "questDefinition": "None",
             "objectiveStatHandle": {
               "dataTable": "None",
               "rowName": "None"


### PR DESCRIPTION
Added Save the World Event Flags for season 6, 7, 8 and 9.
Added theater translations and removed quest requirements so we can access every zone.