### PR TITLE
Big campaign.json Update

### DIFF
--- a/profiles/campaign.json
+++ b/profiles/campaign.json
@@ -17649,7 +17649,13 @@
     "Hero:HID_Commando_045_Chaos_Agent_SR_T05": {
       "templateId": "Hero:HID_Commando_045_Chaos_Agent_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -17693,8 +17699,20 @@
     "Hero:HID_Commando_GrenadeGun_VR_T05": {
       "templateId": "Hero:HID_Commando_GrenadeGun_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -17737,7 +17755,13 @@
     "Hero:HID_Commando_GunTough_RS01_SR_T05": {
       "templateId": "Hero:HID_Commando_GunTough_RS01_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -17759,8 +17783,20 @@
     "Hero:HID_Commando_013_VR_T05": {
       "templateId": "Hero:HID_Commando_013_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -17781,8 +17817,20 @@
     "Hero:HID_Commando_008_VR_T05": {
       "templateId": "Hero:HID_Commando_008_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -17803,7 +17851,13 @@
     "Hero:HID_Commando_GCGrenade_R_T04": {
       "templateId": "Hero:HID_Commando_GCGrenade_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -17825,7 +17879,13 @@
     "Hero:HID_Commando_XBOX_VR_T05": {
       "templateId": "Hero:HID_Commando_XBOX_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -17847,7 +17907,13 @@
     "Hero:HID_Commando_XBOX_SR_T05": {
       "templateId": "Hero:HID_Commando_XBOX_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -17869,7 +17935,13 @@
     "Hero:HID_Commando_XBOX_R_T04": {
       "templateId": "Hero:HID_Commando_XBOX_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -17891,7 +17963,13 @@
     "Hero:HID_Commando_Sony_VR_T05": {
       "templateId": "Hero:HID_Commando_Sony_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -17913,7 +17991,13 @@
     "Hero:HID_Commando_Sony_SR_T05": {
       "templateId": "Hero:HID_Commando_Sony_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -17935,7 +18019,13 @@
     "Hero:HID_Commando_Sony_R_T04": {
       "templateId": "Hero:HID_Commando_Sony_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -17957,8 +18047,20 @@
     "Hero:HID_Commando_ShockDamage_VR_T05": {
       "templateId": "Hero:HID_Commando_ShockDamage_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -17979,8 +18081,20 @@
     "Hero:HID_Commando_ShockDamage_SR_T05": {
       "templateId": "Hero:HID_Commando_ShockDamage_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -18001,7 +18115,13 @@
     "Hero:HID_Commando_ShockDamage_R_T04": {
       "templateId": "Hero:HID_Commando_ShockDamage_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -18023,7 +18143,13 @@
     "Hero:HID_Commando_Myth03_SR_T05": {
       "templateId": "Hero:HID_Commando_Myth03_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier5.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18067,8 +18193,20 @@
     "Hero:HID_Commando_GunTough_VR_T05": {
       "templateId": "Hero:HID_Commando_GunTough_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -18111,8 +18249,20 @@
     "Hero:HID_Commando_GunTough_SR_T05": {
       "templateId": "Hero:HID_Commando_GunTough_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -18133,7 +18283,13 @@
     "Hero:HID_Commando_GunTough_R_T04": {
       "templateId": "Hero:HID_Commando_GunTough_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -18177,7 +18333,13 @@
     "Hero:HID_Commando_GunTough_M_4thJuly_SR_T05": {
       "templateId": "Hero:HID_Commando_GunTough_M_4thJuly_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18199,7 +18361,13 @@
     "Hero:HID_Commando_GunTough_F_4thJuly_SR_T05": {
       "templateId": "Hero:HID_Commando_GunTough_F_4thJuly_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18221,8 +18389,20 @@
     "Hero:HID_Commando_GunHeadshot_VR_T05": {
       "templateId": "Hero:HID_Commando_GunHeadshot_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -18243,7 +18423,13 @@
     "Hero:HID_Commando_GunHeadShot_Starter_M_SR_T05": {
       "templateId": "Hero:HID_Commando_GunHeadShot_Starter_M_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18265,8 +18451,20 @@
     "Hero:HID_Commando_GunHeadshot_SR_T05": {
       "templateId": "Hero:HID_Commando_GunHeadshot_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -18309,7 +18507,13 @@
     "Hero:HID_Commando_GunHeadshotHW_VR_T05": {
       "templateId": "Hero:HID_Commando_GunHeadshotHW_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18331,7 +18535,13 @@
     "Hero:HID_Commando_GunHeadshotHW_SR_T05": {
       "templateId": "Hero:HID_Commando_GunHeadshotHW_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18353,7 +18563,13 @@
     "Hero:HID_Commando_GunHeadshotHW_RS01_SR_T05": {
       "templateId": "Hero:HID_Commando_GunHeadshotHW_RS01_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18375,7 +18591,13 @@
     "Hero:HID_Commando_GrenadeMaster_SR_T05": {
       "templateId": "Hero:HID_Commando_GrenadeMaster_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Mythic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18419,8 +18641,20 @@
     "Hero:HID_Commando_GrenadeGun_SR_T05": {
       "templateId": "Hero:HID_Commando_GrenadeGun_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -18485,8 +18719,20 @@
     "Hero:HID_Commando_GCGrenade_VR_T05": {
       "templateId": "Hero:HID_Commando_GCGrenade_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -18507,7 +18753,13 @@
     "Hero:HID_Commando_GCGrenade_T_VR_T05": {
       "templateId": "Hero:HID_Commando_GCGrenade_T_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18529,7 +18781,13 @@
     "Hero:HID_Commando_GCGrenade_T_SR_T05": {
       "templateId": "Hero:HID_Commando_GCGrenade_T_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18551,8 +18809,20 @@
     "Hero:HID_Commando_GCGrenade_SR_T05": {
       "templateId": "Hero:HID_Commando_GCGrenade_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -18837,7 +19107,13 @@
     "Hero:HID_Commando_035_Caped_Valentine_SR_T05": {
       "templateId": "Hero:HID_Commando_035_Caped_Valentine_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18859,7 +19135,13 @@
     "Hero:HID_Commando_034_ToyTinkerer_VR_T05": {
       "templateId": "Hero:HID_Commando_034_ToyTinkerer_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18881,7 +19163,13 @@
     "Hero:HID_Commando_034_ToyTinkerer_SR_T05": {
       "templateId": "Hero:HID_Commando_034_ToyTinkerer_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -18991,7 +19279,13 @@
     "Hero:HID_Commando_029_DinoSoldier_SR_T05": {
       "templateId": "Hero:HID_Commando_029_DinoSoldier_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19035,7 +19329,13 @@
     "Hero:HID_Commando_027_PirateSoldier_VR_T05": {
       "templateId": "Hero:HID_Commando_027_PirateSoldier_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19057,7 +19357,13 @@
     "Hero:HID_Commando_027_PirateSoldier_SR_T05": {
       "templateId": "Hero:HID_Commando_027_PirateSoldier_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19079,7 +19385,13 @@
     "Hero:HID_Commando_026_SR_T05": {
       "templateId": "Hero:HID_Commando_026_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19167,7 +19479,13 @@
     "Hero:HID_Commando_023_VR_T05": {
       "templateId": "Hero:HID_Commando_023_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19189,7 +19507,13 @@
     "Hero:HID_Commando_023_SR_T05": {
       "templateId": "Hero:HID_Commando_023_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19255,7 +19579,13 @@
     "Hero:HID_Commando_019_SR_T05": {
       "templateId": "Hero:HID_Commando_019_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Mythic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19277,7 +19607,13 @@
     "Hero:HID_Commando_018_SR_T05": {
       "templateId": "Hero:HID_Commando_018_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier5.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19299,8 +19635,20 @@
     "Hero:HID_Commando_017_F_V1_VR_T05": {
       "templateId": "Hero:HID_Commando_017_F_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19321,8 +19669,20 @@
     "Hero:HID_Commando_017_F_V1_SR_T05": {
       "templateId": "Hero:HID_Commando_017_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19343,7 +19703,13 @@
     "Hero:HID_Commando_017_F_V1_R_T04": {
       "templateId": "Hero:HID_Commando_017_F_V1_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -19365,7 +19731,13 @@
     "Hero:HID_Commando_016_M_V1_SR_T05": {
       "templateId": "Hero:HID_Commando_016_M_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19387,7 +19759,13 @@
     "Hero:HID_Commando_016_F_V1_VR_T05": {
       "templateId": "Hero:HID_Commando_016_F_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19409,7 +19787,13 @@
     "Hero:HID_Commando_016_F_V1_SR_T05": {
       "templateId": "Hero:HID_Commando_016_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19431,7 +19815,13 @@
     "Hero:HID_Commando_015_M_V1_VR_T05": {
       "templateId": "Hero:HID_Commando_015_M_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19453,7 +19843,13 @@
     "Hero:HID_Commando_015_M_V1_SR_T05": {
       "templateId": "Hero:HID_Commando_015_M_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19475,7 +19871,13 @@
     "Hero:HID_Commando_015_M_V1_BlockBuster_SR_T05": {
       "templateId": "Hero:HID_Commando_015_M_V1_BlockBuster_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19497,7 +19899,13 @@
     "Hero:HID_Commando_015_F_V1_BlockBuster_SR_T05": {
       "templateId": "Hero:HID_Commando_015_F_V1_BlockBuster_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19519,7 +19927,13 @@
     "Hero:HID_Commando_014_Wukong_SR_T05": {
       "templateId": "Hero:HID_Commando_014_Wukong_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Mythic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19541,8 +19955,20 @@
     "Hero:HID_Commando_014_VR_T05": {
       "templateId": "Hero:HID_Commando_014_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19563,8 +19989,20 @@
     "Hero:HID_Commando_014_SR_T05": {
       "templateId": "Hero:HID_Commando_014_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19585,7 +20023,13 @@
     "Hero:HID_Commando_014_M_SR_T05": {
       "templateId": "Hero:HID_Commando_014_M_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19607,7 +20051,13 @@
     "Hero:HID_Commando_013_StPatricks_M_SR_T05": {
       "templateId": "Hero:HID_Commando_013_StPatricks_M_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19651,7 +20101,13 @@
     "Hero:HID_Commando_013_StPatricks_F_V1_SR_T05": {
       "templateId": "Hero:HID_Commando_013_StPatricks_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19673,8 +20129,20 @@
     "Hero:HID_Commando_013_SR_T05": {
       "templateId": "Hero:HID_Commando_013_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19695,7 +20163,13 @@
     "Hero:HID_Commando_013_R_T04": {
       "templateId": "Hero:HID_Commando_013_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -19717,8 +20191,20 @@
     "Hero:HID_Commando_011_VR_T05": {
       "templateId": "Hero:HID_Commando_011_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19761,8 +20247,20 @@
     "Hero:HID_Commando_011_SR_T05": {
       "templateId": "Hero:HID_Commando_011_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19783,7 +20281,13 @@
     "Hero:HID_Commando_011_R_T04": {
       "templateId": "Hero:HID_Commando_011_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -19805,7 +20309,13 @@
     "Hero:HID_Commando_011_M_SR_T05": {
       "templateId": "Hero:HID_Commando_011_M_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19827,7 +20337,13 @@
     "Hero:HID_Commando_011_M_Easter_SR_T05": {
       "templateId": "Hero:HID_Commando_011_M_Easter_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19849,7 +20365,13 @@
     "Hero:HID_Commando_011_F_V1_RoadTrip_SR_T05": {
       "templateId": "Hero:HID_Commando_011_F_V1_RoadTrip_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19871,8 +20393,20 @@
     "Hero:HID_Commando_010_VR_T05": {
       "templateId": "Hero:HID_Commando_010_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19893,8 +20427,20 @@
     "Hero:HID_Commando_010_SR_T05": {
       "templateId": "Hero:HID_Commando_010_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19915,7 +20461,13 @@
     "Hero:HID_Commando_010_Bday_SR_T05": {
       "templateId": "Hero:HID_Commando_010_Bday_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -19937,8 +20489,20 @@
     "Hero:HID_Commando_009_VR_T05": {
       "templateId": "Hero:HID_Commando_009_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19959,8 +20523,20 @@
     "Hero:HID_Commando_009_SR_T05": {
       "templateId": "Hero:HID_Commando_009_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -19981,7 +20557,13 @@
     "Hero:HID_Commando_009_R_T04": {
       "templateId": "Hero:HID_Commando_009_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20003,8 +20585,20 @@
     "Hero:HID_Commando_009_M_VR_T05": {
       "templateId": "Hero:HID_Commando_009_M_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20025,8 +20619,20 @@
     "Hero:HID_Commando_009_M_SR_T05": {
       "templateId": "Hero:HID_Commando_009_M_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20047,7 +20653,13 @@
     "Hero:HID_Commando_009_M_R_T04": {
       "templateId": "Hero:HID_Commando_009_M_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20069,8 +20681,20 @@
     "Hero:HID_Commando_008_SR_T05": {
       "templateId": "Hero:HID_Commando_008_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20091,7 +20715,13 @@
     "Hero:HID_Commando_008_R_T04": {
       "templateId": "Hero:HID_Commando_008_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20113,7 +20743,13 @@
     "Hero:HID_Commando_008_FoundersM_SR_T05": {
       "templateId": "Hero:HID_Commando_008_FoundersM_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20135,7 +20771,13 @@
     "Hero:HID_Commando_008_FoundersF_SR_T05": {
       "templateId": "Hero:HID_Commando_008_FoundersF_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20157,8 +20799,20 @@
     "Hero:HID_Commando_007_VR_T05": {
       "templateId": "Hero:HID_Commando_007_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20201,8 +20855,20 @@
     "Hero:HID_Commando_007_SR_T05": {
       "templateId": "Hero:HID_Commando_007_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20223,7 +20889,13 @@
     "Hero:HID_Commando_007_R_T04": {
       "templateId": "Hero:HID_Commando_007_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20377,7 +21049,13 @@
     "Hero:HID_Constructor_XBOX_VR_T05": {
       "templateId": "Hero:HID_Constructor_XBOX_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20399,7 +21077,13 @@
     "Hero:HID_Constructor_XBOX_SR_T05": {
       "templateId": "Hero:HID_Constructor_XBOX_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20421,7 +21105,13 @@
     "Hero:HID_Constructor_XBOX_R_T04": {
       "templateId": "Hero:HID_Constructor_XBOX_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20443,7 +21133,13 @@
     "Hero:HID_Constructor_Sony_VR_T05": {
       "templateId": "Hero:HID_Constructor_Sony_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20465,7 +21161,13 @@
     "Hero:HID_Constructor_Sony_SR_T05": {
       "templateId": "Hero:HID_Constructor_Sony_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20487,7 +21189,13 @@
     "Hero:HID_Constructor_Sony_R_T04": {
       "templateId": "Hero:HID_Constructor_Sony_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20509,7 +21217,13 @@
     "Hero:HID_Constructor_RushBASE_VR_T05": {
       "templateId": "Hero:HID_Constructor_RushBASE_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20553,7 +21267,13 @@
     "Hero:HID_Constructor_RushBASE_SR_T05": {
       "templateId": "Hero:HID_Constructor_RushBASE_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20575,7 +21295,13 @@
     "Hero:HID_Constructor_RushBASE_R_T04": {
       "templateId": "Hero:HID_Constructor_RushBASE_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20597,8 +21323,20 @@
     "Hero:HID_Constructor_RushBASE_F_VR_T05": {
       "templateId": "Hero:HID_Constructor_RushBASE_F_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20619,8 +21357,20 @@
     "Hero:HID_Constructor_RushBASE_F_SR_T05": {
       "templateId": "Hero:HID_Constructor_RushBASE_F_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20641,8 +21391,20 @@
     "Hero:HID_Constructor_PlasmaDamage_VR_T05": {
       "templateId": "Hero:HID_Constructor_PlasmaDamage_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20663,8 +21425,20 @@
     "Hero:HID_Constructor_PlasmaDamage_SR_T05": {
       "templateId": "Hero:HID_Constructor_PlasmaDamage_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20685,7 +21459,13 @@
     "Hero:HID_Constructor_PlasmaDamage_R_T04": {
       "templateId": "Hero:HID_Constructor_PlasmaDamage_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20751,8 +21531,20 @@
     "Hero:HID_Constructor_HammerTank_VR_T05": {
       "templateId": "Hero:HID_Constructor_HammerTank_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20773,7 +21565,13 @@
     "Hero:HID_Constructor_HammerTank_R_T04": {
       "templateId": "Hero:HID_Constructor_HammerTank_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -20817,8 +21615,20 @@
     "Hero:HID_Constructor_HammerTank_SR_T05": {
       "templateId": "Hero:HID_Constructor_HammerTank_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20839,8 +21649,20 @@
     "Hero:HID_Constructor_HammerPlasma_VR_T05": {
       "templateId": "Hero:HID_Constructor_HammerPlasma_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20861,8 +21683,20 @@
     "Hero:HID_Constructor_HammerPlasma_SR_T05": {
       "templateId": "Hero:HID_Constructor_HammerPlasma_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20883,7 +21717,13 @@
     "Hero:HID_Constructor_HammerPlasma_4thJuly_SR_T05": {
       "templateId": "Hero:HID_Constructor_HammerPlasma_4thJuly_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -20905,8 +21745,20 @@
     "Hero:HID_Constructor_BaseHyper_SR_T05": {
       "templateId": "Hero:HID_Constructor_BaseHyper_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20927,8 +21779,20 @@
     "Hero:HID_Constructor_BaseHyper_VR_T05": {
       "templateId": "Hero:HID_Constructor_BaseHyper_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -20949,7 +21813,13 @@
     "Hero:HID_Constructor_BaseHyper_R_T04": {
       "templateId": "Hero:HID_Constructor_BaseHyper_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -21015,7 +21885,13 @@
     "Hero:HID_Constructor_BASEBig_SR_T05": {
       "templateId": "Hero:HID_Constructor_BASEBig_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Mythic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21169,7 +22045,13 @@
     "Hero:HID_Constructor_036_Dino_Constructor_VR_T05": {
       "templateId": "Hero:HID_Constructor_036_Dino_Constructor_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21191,7 +22073,13 @@
     "Hero:HID_Constructor_036_Dino_Constructor_SR_T05": {
       "templateId": "Hero:HID_Constructor_036_Dino_Constructor_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21213,7 +22101,13 @@
     "Hero:HID_Constructor_035_Birthday_Constructor_SR_T05": {
       "templateId": "Hero:HID_Constructor_035_Birthday_Constructor_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21235,7 +22129,13 @@
     "Hero:HID_Constructor_035_Birthday_Constructor_VR_T05": {
       "templateId": "Hero:HID_Constructor_035_Birthday_Constructor_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21257,7 +22157,13 @@
     "Hero:HID_Constructor_034_Mechstructor_VR_T05": {
       "templateId": "Hero:HID_Constructor_034_Mechstructor_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21279,7 +22185,13 @@
     "Hero:HID_Constructor_034_Mechstructor_SR_T05": {
       "templateId": "Hero:HID_Constructor_034_Mechstructor_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21345,7 +22257,13 @@
     "Hero:HID_Constructor_032_ToyConstructor_VR_T05": {
       "templateId": "Hero:HID_Constructor_032_ToyConstructor_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21367,7 +22285,13 @@
     "Hero:HID_Constructor_032_ToyConstructor_SR_T05": {
       "templateId": "Hero:HID_Constructor_032_ToyConstructor_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21521,7 +22445,13 @@
     "Hero:HID_Constructor_027_DinoConstructor_SR_T05": {
       "templateId": "Hero:HID_Constructor_027_DinoConstructor_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21543,7 +22473,13 @@
     "Hero:HID_Constructor_026_BombSquadConstructor_VR_T05": {
       "templateId": "Hero:HID_Constructor_026_BombSquadConstructor_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21565,7 +22501,13 @@
     "Hero:HID_Constructor_026_BombSquadConstructor_SR_T05": {
       "templateId": "Hero:HID_Constructor_026_BombSquadConstructor_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21587,7 +22529,13 @@
     "Hero:HID_Constructor_025_ProgressivePirateConstructor_SR_T05": {
       "templateId": "Hero:HID_Constructor_025_ProgressivePirateConstructor_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier5.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21609,7 +22557,13 @@
     "Hero:HID_Constructor_024_PirateConstructor_VR_T05": {
       "templateId": "Hero:HID_Constructor_024_PirateConstructor_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21631,7 +22585,13 @@
     "Hero:HID_Constructor_024_PirateConstructor_SR_T05": {
       "templateId": "Hero:HID_Constructor_024_PirateConstructor_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21697,7 +22657,13 @@
     "Hero:HID_Constructor_021_SR_T05": {
       "templateId": "Hero:HID_Constructor_021_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21719,7 +22685,13 @@
     "Hero:HID_Constructor_020_SR_T05": {
       "templateId": "Hero:HID_Constructor_020_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21785,8 +22757,20 @@
     "Hero:HID_Constructor_017_F_V1_VR_T05": {
       "templateId": "Hero:HID_Constructor_017_F_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -21807,8 +22791,20 @@
     "Hero:HID_Constructor_017_F_V1_SR_T05": {
       "templateId": "Hero:HID_Constructor_017_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -21829,7 +22825,13 @@
     "Hero:HID_Constructor_017_F_V1_R_T04": {
       "templateId": "Hero:HID_Constructor_017_F_V1_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -21851,7 +22853,13 @@
     "Hero:HID_Constructor_016_M_V1_SR_T05": {
       "templateId": "Hero:HID_Constructor_016_M_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21873,7 +22881,13 @@
     "Hero:HID_Constructor_016_M_V1_BlockBuster_SR_T05": {
       "templateId": "Hero:HID_Constructor_016_M_V1_BlockBuster_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21895,7 +22909,13 @@
     "Hero:HID_Constructor_016_F_V1_VR_T05": {
       "templateId": "Hero:HID_Constructor_016_F_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21917,7 +22937,13 @@
     "Hero:HID_Constructor_016_F_V1_SR_T05": {
       "templateId": "Hero:HID_Constructor_016_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -21939,8 +22965,20 @@
     "Hero:HID_Constructor_015_VR_T05": {
       "templateId": "Hero:HID_Constructor_015_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -21961,8 +22999,20 @@
     "Hero:HID_Constructor_015_SR_T05": {
       "templateId": "Hero:HID_Constructor_015_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -21983,7 +23033,13 @@
     "Hero:HID_Constructor_015_R_T04": {
       "templateId": "Hero:HID_Constructor_015_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22005,8 +23061,20 @@
     "Hero:HID_Constructor_014_VR_T05": {
       "templateId": "Hero:HID_Constructor_014_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22027,8 +23095,20 @@
     "Hero:HID_Constructor_014_SR_T05": {
       "templateId": "Hero:HID_Constructor_014_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22049,7 +23129,13 @@
     "Hero:HID_Constructor_014_R_T04": {
       "templateId": "Hero:HID_Constructor_014_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22071,7 +23157,13 @@
     "Hero:HID_Constructor_014_F_SR_T05": {
       "templateId": "Hero:HID_Constructor_014_F_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22093,8 +23185,20 @@
     "Hero:HID_Constructor_013_VR_T05": {
       "templateId": "Hero:HID_Constructor_013_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22137,8 +23241,20 @@
     "Hero:HID_Constructor_013_SR_T05": {
       "templateId": "Hero:HID_Constructor_013_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22159,7 +23275,13 @@
     "Hero:HID_Constructor_013_R_T04": {
       "templateId": "Hero:HID_Constructor_013_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22181,8 +23303,20 @@
     "Hero:HID_Constructor_011_VR_T05": {
       "templateId": "Hero:HID_Constructor_011_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22203,8 +23337,20 @@
     "Hero:HID_Constructor_011_SR_T05": {
       "templateId": "Hero:HID_Constructor_011_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22225,7 +23371,13 @@
     "Hero:HID_Constructor_011_R_T04": {
       "templateId": "Hero:HID_Constructor_011_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22269,8 +23421,20 @@
     "Hero:HID_Constructor_010_VR_T05": {
       "templateId": "Hero:HID_Constructor_010_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22291,8 +23455,20 @@
     "Hero:HID_Constructor_010_SR_T05": {
       "templateId": "Hero:HID_Constructor_010_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22313,8 +23489,20 @@
     "Hero:HID_Constructor_009_VR_T05": {
       "templateId": "Hero:HID_Constructor_009_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22335,8 +23523,20 @@
     "Hero:HID_Constructor_009_SR_T05": {
       "templateId": "Hero:HID_Constructor_009_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22357,7 +23557,13 @@
     "Hero:HID_Constructor_009_R_T04": {
       "templateId": "Hero:HID_Constructor_009_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22379,7 +23585,13 @@
     "Hero:HID_Constructor_008_VR_T05": {
       "templateId": "Hero:HID_Constructor_008_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22401,8 +23613,20 @@
     "Hero:HID_Constructor_008_SR_T05": {
       "templateId": "Hero:HID_Constructor_008_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22423,7 +23647,13 @@
     "Hero:HID_Constructor_008_R_T04": {
       "templateId": "Hero:HID_Constructor_008_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22445,7 +23675,13 @@
     "Hero:HID_Constructor_008_FoundersM_SR_T05": {
       "templateId": "Hero:HID_Constructor_008_FoundersM_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22467,7 +23703,13 @@
     "Hero:HID_Constructor_008_FoundersF_SR_T05": {
       "templateId": "Hero:HID_Constructor_008_FoundersF_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22489,8 +23731,20 @@
     "Hero:HID_Constructor_007_VR_T05": {
       "templateId": "Hero:HID_Constructor_007_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22533,8 +23787,20 @@
     "Hero:HID_Constructor_007_SR_T05": {
       "templateId": "Hero:HID_Constructor_007_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22555,7 +23821,13 @@
     "Hero:HID_Constructor_007_R_T04": {
       "templateId": "Hero:HID_Constructor_007_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22621,7 +23893,13 @@
     "Hero:HID_Ninja_XBOX_VR_T05": {
       "templateId": "Hero:HID_Ninja_XBOX_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22643,7 +23921,13 @@
     "Hero:HID_Ninja_XBOX_SR_T05": {
       "templateId": "Hero:HID_Ninja_XBOX_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22665,7 +23949,13 @@
     "Hero:HID_Ninja_XBOX_R_T04": {
       "templateId": "Hero:HID_Ninja_XBOX_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22687,7 +23977,13 @@
     "Hero:HID_Ninja_Swordmaster_SR_T05": {
       "templateId": "Hero:HID_Ninja_Swordmaster_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Mythic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22709,7 +24005,13 @@
     "Hero:HID_Ninja_StarsRain_VR_T05": {
       "templateId": "Hero:HID_Ninja_StarsRain_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22731,7 +24033,13 @@
     "Hero:HID_Ninja_StarsRain_SR_T05": {
       "templateId": "Hero:HID_Ninja_StarsRain_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22797,7 +24105,13 @@
     "Hero:HID_Ninja_StarsAssassin_FoundersF_SR_T05": {
       "templateId": "Hero:HID_Ninja_StarsAssassin_FoundersF_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22819,8 +24133,20 @@
     "Hero:HID_Ninja_StarsAssassin_VR_T05": {
       "templateId": "Hero:HID_Ninja_StarsAssassin_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22863,8 +24189,20 @@
     "Hero:HID_Ninja_StarsAssassin_SR_T05": {
       "templateId": "Hero:HID_Ninja_StarsAssassin_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -22885,7 +24223,13 @@
     "Hero:HID_Ninja_StarsAssassin_R_T04": {
       "templateId": "Hero:HID_Ninja_StarsAssassin_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22907,7 +24251,13 @@
     "Hero:HID_Ninja_StarsAssassin_FoundersM_SR_T05": {
       "templateId": "Hero:HID_Ninja_StarsAssassin_FoundersM_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22929,7 +24279,13 @@
     "Hero:HID_Ninja_Sony_VR_T05": {
       "templateId": "Hero:HID_Ninja_Sony_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22951,7 +24307,13 @@
     "Hero:HID_Ninja_Sony_SR_T05": {
       "templateId": "Hero:HID_Ninja_Sony_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -22973,7 +24335,13 @@
     "Hero:HID_Ninja_Sony_R_T04": {
       "templateId": "Hero:HID_Ninja_Sony_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -22995,8 +24363,20 @@
     "Hero:HID_Ninja_SmokeDimMak_SR_T05": {
       "templateId": "Hero:HID_Ninja_SmokeDimMak_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -23017,8 +24397,20 @@
     "Hero:HID_Ninja_SmokeDimMak_VR_T05": {
       "templateId": "Hero:HID_Ninja_SmokeDimMak_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -23039,7 +24431,13 @@
     "Hero:HID_Ninja_SmokeDimMak_R_T04": {
       "templateId": "Hero:HID_Ninja_SmokeDimMak_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -23061,8 +24459,20 @@
     "Hero:HID_Ninja_SlashTail_VR_T05": {
       "templateId": "Hero:HID_Ninja_SlashTail_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -23105,8 +24515,20 @@
     "Hero:HID_Ninja_SlashTail_SR_T05": {
       "templateId": "Hero:HID_Ninja_SlashTail_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -23127,7 +24549,13 @@
     "Hero:HID_Ninja_SlashTail_R_T04": {
       "templateId": "Hero:HID_Ninja_SlashTail_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -23149,7 +24577,13 @@
     "Hero:HID_Ninja_SlashBreath_R_T04": {
       "templateId": "Hero:HID_Ninja_SlashBreath_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -23171,8 +24605,20 @@
     "Hero:HID_Ninja_SlashBreath_VR_T05": {
       "templateId": "Hero:HID_Ninja_SlashBreath_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -23193,8 +24639,20 @@
     "Hero:HID_Ninja_SlashBreath_SR_T05": {
       "templateId": "Hero:HID_Ninja_SlashBreath_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -23303,8 +24761,20 @@
     "Hero:HID_Ninja_043_Cranium_VR_T05": {
       "templateId": "Hero:HID_Ninja_043_Cranium_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier4.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier4.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -23325,8 +24795,20 @@
     "Hero:HID_Ninja_043_Cranium_SR_T05": {
       "templateId": "Hero:HID_Ninja_043_Cranium_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier4.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier4.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -23479,7 +24961,13 @@
     "Hero:HID_Ninja_039_Dino_Ninja_VR_T05": {
       "templateId": "Hero:HID_Ninja_039_Dino_Ninja_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23501,7 +24989,13 @@
     "Hero:HID_Ninja_039_Dino_Ninja_SR_T05": {
       "templateId": "Hero:HID_Ninja_039_Dino_Ninja_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23523,7 +25017,13 @@
     "Hero:HID_Ninja_038_Male_Ninja_Pirate_VR_T05": {
       "templateId": "Hero:HID_Ninja_038_Male_Ninja_Pirate_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23545,7 +25045,13 @@
     "Hero:HID_Ninja_038_Male_Ninja_Pirate_SR_T05": {
       "templateId": "Hero:HID_Ninja_038_Male_Ninja_Pirate_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23567,7 +25073,13 @@
     "Hero:HID_Ninja_037_Junk_Samurai_SR_T05": {
       "templateId": "Hero:HID_Ninja_037_Junk_Samurai_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23589,7 +25101,13 @@
     "Hero:HID_Ninja_037_Junk_Samurai_VR_T05": {
       "templateId": "Hero:HID_Ninja_037_Junk_Samurai_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23743,7 +25261,13 @@
     "Hero:HID_Ninja_030_RetroSciFiNinja_SR_T05": {
       "templateId": "Hero:HID_Ninja_030_RetroSciFiNinja_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23765,7 +25289,13 @@
     "Hero:HID_Ninja_030_RetroSciFiNinja_VR_T05": {
       "templateId": "Hero:HID_Ninja_030_RetroSciFiNinja_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23787,7 +25317,13 @@
     "Hero:HID_Ninja_029_DinoNinja_SR_T05": {
       "templateId": "Hero:HID_Ninja_029_DinoNinja_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23831,7 +25367,13 @@
     "Hero:HID_Ninja_027_BunnyNinja_SR_T05": {
       "templateId": "Hero:HID_Ninja_027_BunnyNinja_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23853,7 +25395,13 @@
     "Hero:HID_Ninja_026_RedDragonNinja_SR_T05": {
       "templateId": "Hero:HID_Ninja_026_RedDragonNinja_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier4.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23875,7 +25423,13 @@
     "Hero:HID_Ninja_025_PirateNinja_VR_T05": {
       "templateId": "Hero:HID_Ninja_025_PirateNinja_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23897,7 +25451,13 @@
     "Hero:HID_Ninja_025_PirateNinja_SR_T05": {
       "templateId": "Hero:HID_Ninja_025_PirateNinja_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23919,7 +25479,13 @@
     "Hero:HID_Ninja_024_SR_T05": {
       "templateId": "Hero:HID_Ninja_024_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23941,7 +25507,13 @@
     "Hero:HID_Ninja_023_SR_T05": {
       "templateId": "Hero:HID_Ninja_023_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier5.Mythic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -23963,7 +25535,13 @@
     "Hero:HID_Ninja_022_SR_T05": {
       "templateId": "Hero:HID_Ninja_022_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -24007,7 +25585,13 @@
     "Hero:HID_Ninja_020_SR_T05": {
       "templateId": "Hero:HID_Ninja_020_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -24029,7 +25613,13 @@
     "Hero:HID_Ninja_019_SR_T05": {
       "templateId": "Hero:HID_Ninja_019_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier5.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -24073,8 +25663,20 @@
     "Hero:HID_Ninja_017_M_V1_VR_T05": {
       "templateId": "Hero:HID_Ninja_017_M_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24095,8 +25697,20 @@
     "Hero:HID_Ninja_017_M_V1_SR_T05": {
       "templateId": "Hero:HID_Ninja_017_M_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24117,7 +25731,13 @@
     "Hero:HID_Ninja_017_M_V1_R_T04": {
       "templateId": "Hero:HID_Ninja_017_M_V1_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -24139,7 +25759,13 @@
     "Hero:HID_Ninja_016_M_V1_VR_T05": {
       "templateId": "Hero:HID_Ninja_016_M_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -24161,7 +25787,13 @@
     "Hero:HID_Ninja_016_M_V1_SR_T05": {
       "templateId": "Hero:HID_Ninja_016_M_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -24183,7 +25815,13 @@
     "Hero:HID_Ninja_016_F_V1_SR_T05": {
       "templateId": "Hero:HID_Ninja_016_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -24205,8 +25843,20 @@
     "Hero:HID_Ninja_015_F_V1_VR_T05": {
       "templateId": "Hero:HID_Ninja_015_F_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24249,8 +25899,20 @@
     "Hero:HID_Ninja_015_F_V1_SR_T05": {
       "templateId": "Hero:HID_Ninja_015_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24271,7 +25933,13 @@
     "Hero:HID_Ninja_015_F_V1_R_T04": {
       "templateId": "Hero:HID_Ninja_015_F_V1_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -24315,8 +25983,20 @@
     "Hero:HID_Ninja_014_VR_T05": {
       "templateId": "Hero:HID_Ninja_014_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24359,8 +26039,20 @@
     "Hero:HID_Ninja_014_SR_T05": {
       "templateId": "Hero:HID_Ninja_014_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24381,7 +26073,13 @@
     "Hero:HID_Ninja_014_R_T04": {
       "templateId": "Hero:HID_Ninja_014_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -24403,7 +26101,13 @@
     "Hero:HID_Ninja_014_F_SR_T05": {
       "templateId": "Hero:HID_Ninja_014_F_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -24425,8 +26129,20 @@
     "Hero:HID_Ninja_013_VR_T05": {
       "templateId": "Hero:HID_Ninja_013_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24447,8 +26163,20 @@
     "Hero:HID_Ninja_013_SR_T05": {
       "templateId": "Hero:HID_Ninja_013_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24469,7 +26197,13 @@
     "Hero:HID_Ninja_013_R_T04": {
       "templateId": "Hero:HID_Ninja_013_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -24491,8 +26225,20 @@
     "Hero:HID_Ninja_011_VR_T05": {
       "templateId": "Hero:HID_Ninja_011_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24513,8 +26259,20 @@
     "Hero:HID_Ninja_011_SR_T05": {
       "templateId": "Hero:HID_Ninja_011_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24535,7 +26293,13 @@
     "Hero:HID_Ninja_011_R_T04": {
       "templateId": "Hero:HID_Ninja_011_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -24557,8 +26321,20 @@
     "Hero:HID_Ninja_010_VR_T05": {
       "templateId": "Hero:HID_Ninja_010_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24579,8 +26355,20 @@
     "Hero:HID_Ninja_010_SR_T05": {
       "templateId": "Hero:HID_Ninja_010_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24601,8 +26389,20 @@
     "Hero:HID_Ninja_010_F_VR_T05": {
       "templateId": "Hero:HID_Ninja_010_F_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24623,8 +26423,20 @@
     "Hero:HID_Ninja_010_F_SR_T05": {
       "templateId": "Hero:HID_Ninja_010_F_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24645,8 +26457,20 @@
     "Hero:HID_Ninja_009_VR_T05": {
       "templateId": "Hero:HID_Ninja_009_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24667,8 +26491,20 @@
     "Hero:HID_Ninja_009_SR_T05": {
       "templateId": "Hero:HID_Ninja_009_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24689,7 +26525,13 @@
     "Hero:HID_Ninja_009_R_T04": {
       "templateId": "Hero:HID_Ninja_009_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -24711,7 +26553,13 @@
     "Hero:HID_Ninja_009_F_Valentine_SR_T05": {
       "templateId": "Hero:HID_Ninja_009_F_Valentine_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -24733,8 +26581,20 @@
     "Hero:HID_Ninja_008_VR_T05": {
       "templateId": "Hero:HID_Ninja_008_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24755,8 +26615,20 @@
     "Hero:HID_Ninja_008_SR_T05": {
       "templateId": "Hero:HID_Ninja_008_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24777,7 +26649,13 @@
     "Hero:HID_Ninja_008_R_T04": {
       "templateId": "Hero:HID_Ninja_008_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -24799,8 +26677,20 @@
     "Hero:HID_Ninja_007_VR_T05": {
       "templateId": "Hero:HID_Ninja_007_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24843,8 +26733,20 @@
     "Hero:HID_Ninja_007_SR_T05": {
       "templateId": "Hero:HID_Ninja_007_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24865,7 +26767,13 @@
     "Hero:HID_Ninja_007_R_T04": {
       "templateId": "Hero:HID_Ninja_007_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -24887,8 +26795,20 @@
     "Hero:HID_Outlander_ZonePistol_VR_T05": {
       "templateId": "Hero:HID_Outlander_ZonePistol_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24909,8 +26829,20 @@
     "Hero:HID_Outlander_ZonePistol_SR_T05": {
       "templateId": "Hero:HID_Outlander_ZonePistol_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -24931,7 +26863,13 @@
     "Hero:HID_Outlander_ZonePistol_R_T04": {
       "templateId": "Hero:HID_Outlander_ZonePistol_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -25019,7 +26957,13 @@
     "Hero:HID_Outlander_ZoneHarvest_SR_T05": {
       "templateId": "Hero:HID_Outlander_ZoneHarvest_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25041,7 +26985,13 @@
     "Hero:HID_Outlander_ZoneHarvest_VR_T05": {
       "templateId": "Hero:HID_Outlander_ZoneHarvest_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25063,7 +27013,13 @@
     "Hero:HID_Outlander_ZoneHarvest_R_T04": {
       "templateId": "Hero:HID_Outlander_ZoneHarvest_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -25085,7 +27041,13 @@
     "Hero:HID_Outlander_ZoneHarvest_BlockBuster_SR_T05": {
       "templateId": "Hero:HID_Outlander_ZoneHarvest_BlockBuster_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25129,7 +27091,13 @@
     "Hero:HID_Outlander_ZoneFragment_SR_T05": {
       "templateId": "Hero:HID_Outlander_ZoneFragment_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Mythic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25151,7 +27119,13 @@
     "Hero:HID_Outlander_XBOX_VR_T05": {
       "templateId": "Hero:HID_Outlander_XBOX_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25173,7 +27147,13 @@
     "Hero:HID_Outlander_XBOX_SR_T05": {
       "templateId": "Hero:HID_Outlander_XBOX_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25195,7 +27175,13 @@
     "Hero:HID_Outlander_XBOX_R_T04": {
       "templateId": "Hero:HID_Outlander_XBOX_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -25217,8 +27203,20 @@
     "Hero:HID_Outlander_SphereFragment_VR_T05": {
       "templateId": "Hero:HID_Outlander_SphereFragment_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -25261,8 +27259,20 @@
     "Hero:HID_Outlander_SphereFragment_SR_T05": {
       "templateId": "Hero:HID_Outlander_SphereFragment_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -25283,7 +27293,13 @@
     "Hero:HID_Outlander_SphereFragment_R_T04": {
       "templateId": "Hero:HID_Outlander_SphereFragment_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -25305,7 +27321,13 @@
     "Hero:HID_Outlander_Sony_VR_T05": {
       "templateId": "Hero:HID_Outlander_Sony_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25327,7 +27349,13 @@
     "Hero:HID_Outlander_Sony_SR_T05": {
       "templateId": "Hero:HID_Outlander_Sony_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25349,7 +27377,13 @@
     "Hero:HID_Outlander_Sony_R_T04": {
       "templateId": "Hero:HID_Outlander_Sony_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -25371,7 +27405,13 @@
     "Hero:HID_Outlander_PunchPhase_VR_T05": {
       "templateId": "Hero:HID_Outlander_PunchPhase_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25415,7 +27455,13 @@
     "Hero:HID_Outlander_PunchPhase_SR_T05": {
       "templateId": "Hero:HID_Outlander_PunchPhase_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25437,7 +27483,13 @@
     "Hero:HID_Outlander_PunchPhase_R_T04": {
       "templateId": "Hero:HID_Outlander_PunchPhase_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier1.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -25459,8 +27511,20 @@
     "Hero:HID_Outlander_PunchDamage_SR_T05": {
       "templateId": "Hero:HID_Outlander_PunchDamage_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -25481,8 +27545,20 @@
     "Hero:HID_Outlander_PunchDamage_VR_T05": {
       "templateId": "Hero:HID_Outlander_PunchDamage_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -25503,7 +27579,13 @@
     "Hero:HID_Outlander_Myth03_SR_T05": {
       "templateId": "Hero:HID_Outlander_Myth03_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Mythic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25525,7 +27607,13 @@
     "Hero:HID_Outlander_Myth02_SR_T05": {
       "templateId": "Hero:HID_Outlander_Myth02_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier5.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25723,7 +27811,13 @@
     "Hero:HID_Outlander_036_Dino_Outlander_VR_T05": {
       "templateId": "Hero:HID_Outlander_036_Dino_Outlander_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25745,7 +27839,13 @@
     "Hero:HID_Outlander_036_Dino_Outlander_SR_T05": {
       "templateId": "Hero:HID_Outlander_036_Dino_Outlander_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25767,7 +27867,13 @@
     "Hero:HID_Outlander_035_Palespooky_Outlander_Holiday_SR_T05": {
       "templateId": "Hero:HID_Outlander_035_Palespooky_Outlander_Holiday_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25789,7 +27895,13 @@
     "Hero:HID_Outlander_035_Palespooky_Outlander_Holiday_VR_T05": {
       "templateId": "Hero:HID_Outlander_035_Palespooky_Outlander_Holiday_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -25899,7 +28011,13 @@
     "Hero:HID_Outlander_031_HalloweenOutlander_SR_T05": {
       "templateId": "Hero:HID_Outlander_031_HalloweenOutlander_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26031,7 +28149,13 @@
     "Hero:HID_Outlander_027_DinoOutlander_SR_T05": {
       "templateId": "Hero:HID_Outlander_027_DinoOutlander_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26075,7 +28199,13 @@
     "Hero:HID_Outlander_025_PirateOutlander_VR_T05": {
       "templateId": "Hero:HID_Outlander_025_PirateOutlander_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26097,7 +28227,13 @@
     "Hero:HID_Outlander_025_PirateOutlander_SR_T05": {
       "templateId": "Hero:HID_Outlander_025_PirateOutlander_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26163,7 +28299,13 @@
     "Hero:HID_Outlander_022_SR_T05": {
       "templateId": "Hero:HID_Outlander_022_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier4.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26251,7 +28393,13 @@
     "Hero:HID_Outlander_017_M_V1_VR_T05": {
       "templateId": "Hero:HID_Outlander_017_M_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26273,7 +28421,13 @@
     "Hero:HID_Outlander_017_M_V1_SR_T05": {
       "templateId": "Hero:HID_Outlander_017_M_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26295,7 +28449,13 @@
     "Hero:HID_Outlander_016_M_V1_VR_T05": {
       "templateId": "Hero:HID_Outlander_016_M_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26317,7 +28477,13 @@
     "Hero:HID_Outlander_016_M_V1_SR_T05": {
       "templateId": "Hero:HID_Outlander_016_M_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26339,7 +28505,13 @@
     "Hero:HID_Outlander_016_F_V1_SR_T05": {
       "templateId": "Hero:HID_Outlander_016_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26361,8 +28533,20 @@
     "Hero:HID_Outlander_015_F_V1_VR_T05": {
       "templateId": "Hero:HID_Outlander_015_F_V1_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26383,8 +28567,20 @@
     "Hero:HID_Outlander_015_F_V1_SR_T05": {
       "templateId": "Hero:HID_Outlander_015_F_V1_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26405,7 +28601,13 @@
     "Hero:HID_Outlander_015_F_V1_R_T04": {
       "templateId": "Hero:HID_Outlander_015_F_V1_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -26427,8 +28629,20 @@
     "Hero:HID_Outlander_014_VR_T05": {
       "templateId": "Hero:HID_Outlander_014_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26449,8 +28663,20 @@
     "Hero:HID_Outlander_014_SR_T05": {
       "templateId": "Hero:HID_Outlander_014_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26471,7 +28697,13 @@
     "Hero:HID_Outlander_014_R_T04": {
       "templateId": "Hero:HID_Outlander_014_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -26493,7 +28725,13 @@
     "Hero:HID_Outlander_014_M_SR_T05": {
       "templateId": "Hero:HID_Outlander_014_M_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26515,8 +28753,20 @@
     "Hero:HID_Outlander_013_VR_T05": {
       "templateId": "Hero:HID_Outlander_013_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26537,7 +28787,13 @@
     "Hero:HID_Outlander_013_StPatricks_SR_T05": {
       "templateId": "Hero:HID_Outlander_013_StPatricks_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26559,8 +28815,20 @@
     "Hero:HID_Outlander_013_SR_T05": {
       "templateId": "Hero:HID_Outlander_013_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26581,8 +28849,20 @@
     "Hero:HID_Outlander_011_VR_T05": {
       "templateId": "Hero:HID_Outlander_011_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26603,8 +28883,20 @@
     "Hero:HID_Outlander_011_SR_T05": {
       "templateId": "Hero:HID_Outlander_011_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26625,8 +28917,20 @@
     "Hero:HID_Outlander_010_VR_T05": {
       "templateId": "Hero:HID_Outlander_010_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26647,8 +28951,20 @@
     "Hero:HID_Outlander_010_SR_T05": {
       "templateId": "Hero:HID_Outlander_010_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26669,8 +28985,20 @@
     "Hero:HID_Outlander_010_M_VR_T05": {
       "templateId": "Hero:HID_Outlander_010_M_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26691,8 +29019,20 @@
     "Hero:HID_Outlander_010_M_SR_T05": {
       "templateId": "Hero:HID_Outlander_010_M_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26713,7 +29053,13 @@
     "Hero:HID_Outlander_010_M_4thJuly_SR_T05": {
       "templateId": "Hero:HID_Outlander_010_M_4thJuly_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26735,8 +29081,20 @@
     "Hero:HID_Outlander_009_VR_T05": {
       "templateId": "Hero:HID_Outlander_009_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26757,8 +29115,20 @@
     "Hero:HID_Outlander_009_SR_T05": {
       "templateId": "Hero:HID_Outlander_009_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26779,7 +29149,13 @@
     "Hero:HID_Outlander_009_R_T04": {
       "templateId": "Hero:HID_Outlander_009_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -26801,8 +29177,20 @@
     "Hero:HID_Outlander_008_VR_T05": {
       "templateId": "Hero:HID_Outlander_008_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26823,8 +29211,20 @@
     "Hero:HID_Outlander_008_SR_T05": {
       "templateId": "Hero:HID_Outlander_008_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26845,7 +29245,13 @@
     "Hero:HID_Outlander_008_R_T04": {
       "templateId": "Hero:HID_Outlander_008_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -26867,7 +29273,13 @@
     "Hero:HID_Outlander_008_FoundersM_SR_T05": {
       "templateId": "Hero:HID_Outlander_008_FoundersM_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26889,7 +29301,13 @@
     "Hero:HID_Outlander_008_FoundersF_SR_T05": {
       "templateId": "Hero:HID_Outlander_008_FoundersF_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,
@@ -26911,8 +29329,20 @@
     "Hero:HID_Outlander_007_VR_T05": {
       "templateId": "Hero:HID_Outlander_007_VR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Epic",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Epic",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26955,8 +29385,20 @@
     "Hero:HID_Outlander_007_SR_T05": {
       "templateId": "Hero:HID_Outlander_007_SR_T05",
       "attributes": {
-        "outfitvariants": [],
-        "backblingvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
+        "backblingvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier3.Legendary",
+            "owned": []
+          }
+        ],
         "gender": 0,
         "level": 50,
         "item_seen": true,
@@ -26977,7 +29419,13 @@
     "Hero:HID_Outlander_007_R_T04": {
       "templateId": "Hero:HID_Outlander_007_R_T04",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Rare",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 40,
@@ -26999,7 +29447,13 @@
     "Hero:HID_Outlander_007_RS01_SR_T05": {
       "templateId": "Hero:HID_Outlander_007_RS01_SR_T05",
       "attributes": {
-        "outfitvariants": [],
+        "outfitvariants": [
+          {
+            "channel": "Parts",
+            "active": "CampaignHero.Tier2.Legendary",
+            "owned": []
+          }
+        ],
         "backblingvariants": [],
         "gender": 0,
         "level": 50,

--- a/profiles/campaign.json
+++ b/profiles/campaign.json
@@ -462,17 +462,6 @@
       },
       "quantity": 1
     },
-    "62c77c28-f0b7-441b-8a48-f71a6d7c1c6d": {
-      "templateId": "AccountResource:reagent_alteration_ele_fire",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 2378653
-    },
     "a20d050d-55db-42f6-8702-76f44e73900d": {
       "templateId": "Quest:reactivequest_roadhome",
       "attributes": {
@@ -1076,17 +1065,6 @@
         "set_bonus": "Homebase.Worker.SetBonus.IsRangedDamageLow"
       },
       "quantity": 1
-    },
-    "ed452cb4-b690-4973-938b-1913ec4a2ccf": {
-      "templateId": "AccountResource:reagent_alteration_upgrade_uc",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 6362897
     },
     "98b32eca-9e87-4ddf-9d3d-93bd8928895b": {
       "templateId": "Worker:workerbasic_sr_t01",
@@ -2575,17 +2553,6 @@
       },
       "quantity": 1
     },
-    "af5f57fb-2c6c-4dfc-8988-5c63caefa0ea": {
-      "templateId": "AccountResource:eventcurrency_scaling",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 2240789
-    },
     "df119146-ca37-4aac-98d1-a7736fc42ee6": {
       "templateId": "Quest:wargames_visibilityquest_wargame_riotcity",
       "attributes": {
@@ -2746,26 +2713,6 @@
         "completion_s11_holdfastquest_season_misty": 0,
         "max_level_bonus": 0,
         "xp": 0,
-        "favorite": false
-      },
-      "quantity": 1
-    },
-    "0f58193f-5089-4535-9a8d-c3f0fa1ae3a1": {
-      "templateId": "Quest:outpostquest_t1_l6",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-19T19:48:35.037Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "completion_complete_outpost_1_6": 1,
         "favorite": false
       },
       "quantity": 1
@@ -3151,26 +3098,6 @@
       },
       "quantity": 968395829
     },
-    "116a87da-d383-428c-b446-54e3f8c3c201": {
-      "templateId": "Quest:outpostquest_t1_l9",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-01T01:15:21.069Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "favorite": false,
-        "completion_complete_outpost_1_9": 1
-      },
-      "quantity": 1
-    },
     "77e6b823-3668-4e8f-acac-a13e3c36649e": {
       "templateId": "Quest:wargames_visibilityquest_wargame_pods",
       "attributes": {
@@ -3253,17 +3180,6 @@
         "favorite": false
       },
       "quantity": 1
-    },
-    "c16370df-7f0b-486b-854c-605d3cd1b742": {
-      "templateId": "AccountResource:voucher_basicpack",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 3023489
     },
     "1375bd56-7fbb-4d07-9652-abe0b3708330": {
       "templateId": "HomebaseNode:questreward_expedition_dirtbike3",
@@ -3864,17 +3780,6 @@
       },
       "quantity": 1
     },
-    "e3274352-0816-4045-bf06-4fe14262ebbd": {
-      "templateId": "AccountResource:personnelxp",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 648342952
-    },
     "0b15f777-9443-4351-b780-6cd5cc75f31b": {
       "templateId": "Token:receivemtxcurrency",
       "attributes": {
@@ -4201,26 +4106,6 @@
         "challenge_linked_quest_parent": "",
         "max_level_bonus": 0,
         "xp": 0,
-        "favorite": false
-      },
-      "quantity": 1
-    },
-    "14ebcd02-e84b-4ac6-80f2-61a1e6eb010a": {
-      "templateId": "Quest:outpostquest_t1_l7",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-22T18:17:42.686Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "completion_complete_outpost_1_7": 1,
         "favorite": false
       },
       "quantity": 1
@@ -4711,26 +4596,6 @@
       },
       "quantity": 1
     },
-    "a3cc308e-3d64-42ce-abb6-aac921844938": {
-      "templateId": "Quest:outpostquest_t1_l8",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-26T18:03:33.698Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "favorite": false,
-        "completion_complete_outpost_1_8": 1
-      },
-      "quantity": 1
-    },
     "de19e55b-84b0-48c4-87ca-5f1e53856d01": {
       "templateId": "Quest:tutorial_loadout_support1",
       "attributes": {
@@ -4974,17 +4839,6 @@
       },
       "quantity": 1
     },
-    "23f6fad1-ac04-4f3e-9a95-4597fc06c5c8": {
-      "templateId": "AccountResource:reagent_alteration_upgrade_vr",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 2608499
-    },
     "ee438717-2652-4637-b1ce-8208c45933b8": {
       "templateId": "Worker:managerexplorer_r_t01",
       "attributes": {
@@ -5133,17 +4987,6 @@
       },
       "quantity": 1
     },
-    "5b4537ec-1fff-424c-b8a3-07d2f3ff1169": {
-      "templateId": "AccountResource:reagent_weapons",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 1802572
-    },
     "5d8d400c-506b-4b75-843c-a5bda783b7b5": {
       "templateId": "Stat:fortitude",
       "attributes": {
@@ -5154,28 +4997,6 @@
         "favorite": false
       },
       "quantity": 5000
-    },
-    "4030e2d1-ce9d-4d72-ae3c-986568a40477": {
-      "templateId": "AccountResource:schematicxp",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 370449162
-    },
-    "c48f6525-cbe5-497b-87aa-8fe772c5afbb": {
-      "templateId": "AccountResource:reagent_evolverarity_r",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 7109842
     },
     "19b4591e-ed2f-4b9a-b21c-ea7bc193e236": {
       "templateId": "Worker:workerbasic_vr_t01",
@@ -5241,17 +5062,6 @@
       },
       "quantity": 1
     },
-    "286be2b0-c6b1-413f-902f-052e2570df4a": {
-      "templateId": "AccountResource:reagent_people",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 3999781
-    },
     "c8b838d5-2077-4192-8877-d38e9bb8a04c": {
       "templateId": "Quest:homebaseonboardingafteroutpost",
       "attributes": {
@@ -5273,17 +5083,6 @@
         "favorite": false
       },
       "quantity": 1
-    },
-    "6be66163-d4ae-465d-b0d4-937d9d64b7fd": {
-      "templateId": "AccountResource:reagent_evolverarity_sr",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 9980316
     },
     "bff3da51-c78d-4458-9865-9c8605518dc4": {
       "templateId": "HomebaseNode:questreward_evolution3",
@@ -5319,17 +5118,6 @@
         "completion_complete_encampment_1_diff4": 4
       },
       "quantity": 1
-    },
-    "8bf4df23-88ef-492c-b3e1-d5eed48cc1d5": {
-      "templateId": "AccountResource:reagent_alteration_generic",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 8014533
     },
     "98ae1807-f516-42d4-9721-5fab57424d55": {
       "templateId": "Quest:starlightquest_kill_mimics",
@@ -5747,17 +5535,6 @@
       },
       "quantity": 5000
     },
-    "70bc37c0-8298-4d94-9844-938d8f0d58b7": {
-      "templateId": "AccountResource:reagent_c_t02",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 4923098
-    },
     "e245fbb8-a31e-41f8-a16e-bacd1ea6fab9": {
       "templateId": "HomebaseNode:questreward_plankerton_squad_ssd4",
       "attributes": {
@@ -5873,17 +5650,6 @@
         "set_bonus": "Homebase.Worker.SetBonus.IsRangedDamageLow"
       },
       "quantity": 1
-    },
-    "1d163a14-5eb5-400d-81bc-b0118c4a1767": {
-      "templateId": "AccountResource:reagent_c_t01",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 4120062
     },
     "258b2f63-04e8-4d24-9a84-55ed52dbd456": {
       "templateId": "Quest:reactivequest_riftdata",
@@ -6457,17 +6223,6 @@
       },
       "quantity": 1
     },
-    "c212eadf-38fa-4850-9c52-c05577729639": {
-      "templateId": "AccountResource:reagent_alteration_ele_water",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 5400097
-    },
     "f2a426e7-dbba-4cdc-b9d3-7e8a78da5a21": {
       "templateId": "Quest:pickaxequest_stw005_tier_6",
       "attributes": {
@@ -7006,17 +6761,6 @@
       },
       "quantity": 1
     },
-    "e4b4befb-fe4a-4010-983b-e6263d8155b2": {
-      "templateId": "AccountResource:reagent_alteration_ele_nature",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 6975876
-    },
     "b8cc42f5-21f1-4e56-b5c2-6fd96cf3b642": {
       "templateId": "Quest:stonewoodquest_joelkarolina_killhusks",
       "attributes": {
@@ -7140,17 +6884,6 @@
         "item_seen": false
       },
       "quantity": 1
-    },
-    "93a5b4fe-90a1-4eda-b2ad-c45c00e91b06": {
-      "templateId": "AccountResource:voucher_herobuyback",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 2994750
     },
     "628877c6-3cac-4cff-bc9b-650680457084": {
       "templateId": "Quest:reactivequest_firehusks",
@@ -7914,27 +7647,6 @@
       },
       "quantity": 1
     },
-    "0845ae66-9465-4b9a-b8df-724e31e6bd03": {
-      "templateId": "Quest:outpostquest_t1_l4",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-10T19:19:56.344Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "completion_complete_outpost_1_4": 1,
-        "completion_custom_defendersupplyreceived": 0,
-        "favorite": false
-      },
-      "quantity": 1
-    },
     "2a001fc6-76ef-4ba8-b50f-3b5245369e9d": {
       "templateId": "Quest:reactivequest_poisonlobbers",
       "attributes": {
@@ -8046,17 +7758,6 @@
         "favorite": false
       },
       "quantity": 1
-    },
-    "583bcfae-6b6d-4285-9a78-da6403ff90ec": {
-      "templateId": "AccountResource:reagent_alteration_upgrade_r",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 7670792
     },
     "559f9441-f709-47df-b8e5-11660746c0c9": {
       "templateId": "Quest:plankertonquest_fetch_searchingforlab",
@@ -8205,26 +7906,6 @@
         "expedition_success_chance": 0,
         "xp": 0,
         "expedition_expiration_start_time": "2020-02-05T21:42:19.784Z",
-        "favorite": false
-      },
-      "quantity": 1
-    },
-    "fee50700-9438-4d67-b1e6-6a91816ca216": {
-      "templateId": "Quest:outpostquest_t1_l10",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "completion_complete_outpost_1_10": 1,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-01T23:22:54.668Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
         "favorite": false
       },
       "quantity": 1
@@ -8737,26 +8418,6 @@
         "max_level_bonus": 0,
         "xp": 0,
         "completion_cannyvalley_reactive_survey": 7,
-        "favorite": false
-      },
-      "quantity": 1
-    },
-    "9c86f06d-1d0a-4d33-b250-9ce2a7436392": {
-      "templateId": "Quest:outpostquest_t1_l2",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-25T21:04:23.597Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "completion_complete_outpost_1_2": 1,
         "favorite": false
       },
       "quantity": 1
@@ -10548,26 +10209,6 @@
       },
       "quantity": 1
     },
-    "fa04bb99-7bde-4ab2-ac28-5f17462f47a7": {
-      "templateId": "Quest:outpostquest_t1_l5",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-17T18:08:45.147Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "completion_complete_outpost_1_5": 1,
-        "favorite": false
-      },
-      "quantity": 1
-    },
     "5963a3f6-96fb-41bc-b30e-7f065c596b37": {
       "templateId": "HomebaseNode:questreward_evolution",
       "attributes": {
@@ -10695,17 +10336,6 @@
       },
       "quantity": 1
     },
-    "241c02ed-dc00-40f6-a935-ebb10ffbe5ff": {
-      "templateId": "AccountResource:reagent_c_t04",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 5356130
-    },
     "607ad331-cc3b-461d-915c-db24b89f68eb": {
       "templateId": "Quest:challenge_missionaccomplished_9",
       "attributes": {
@@ -10745,17 +10375,6 @@
         "completion_wargames_visibilityquest_wargame_saucer": 0
       },
       "quantity": 1
-    },
-    "8bc63bbd-2112-4810-9d24-0a9199d665b2": {
-      "templateId": "AccountResource:reagent_alteration_upgrade_sr",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 9884342
     },
     "8ebaf589-95ef-4fe2-9bf7-f9f8b075d288": {
       "templateId": "Quest:challenge_upgradealteration",
@@ -11243,26 +10862,6 @@
       },
       "quantity": 1
     },
-    "1f791aec-e24f-4a0f-8ec4-5a102c33beae": {
-      "templateId": "Quest:outpostquest_t1_endless",
-      "attributes": {
-        "level": -1,
-        "item_seen": false,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "completion_complete_outpost_1_endless": 0,
-        "quest_state": "Active",
-        "last_state_change_time": "2020-01-24T16:38:06.807Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 1
-    },
     "36b1df04-2669-4c6a-bf41-5b0dfc954fe2": {
       "templateId": "Quest:reactivequest_blasters",
       "attributes": {
@@ -11414,17 +11013,6 @@
         "favorite": false
       },
       "quantity": 1
-    },
-    "e3da4012-16ab-4d6b-bf83-19f9acd6a68c": {
-      "templateId": "AccountResource:heroxp",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 419858132
     },
     "6c352060-a858-49a7-97a9-48c51696081d": {
       "templateId": "Quest:wargames_visibilityquest_challenge_explode",
@@ -11947,17 +11535,6 @@
       },
       "quantity": 1
     },
-    "83422daa-a674-4d43-85fb-a08fc401135e": {
-      "templateId": "AccountResource:reagent_c_t03",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 8525913
-    },
     "0d0d8fb9-f973-4551-bd2a-008ef50343df": {
       "templateId": "Quest:stonewoodquest_tutorial_collectionbook",
       "attributes": {
@@ -12335,28 +11912,6 @@
       },
       "quantity": 1
     },
-    "196628b1-8877-424d-ac39-3de19818d48b": {
-      "templateId": "Quest:outpostquest_t1_l1",
-      "attributes": {
-        "level": -1,
-        "completion_custom_supplydropreceived": 1,
-        "completion_complete_outpost_1_1": 1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "completion_custom_deployoutpost": 1,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-25T19:09:24.305Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 1
-    },
     "b44a2515-42f3-4fce-9128-42b3d1a5e419": {
       "templateId": "Worker:workerbasic_vr_t01",
       "attributes": {
@@ -12450,27 +12005,6 @@
         "challenge_linked_quest_parent": "",
         "max_level_bonus": 0,
         "xp": 0,
-        "favorite": false
-      },
-      "quantity": 1
-    },
-    "86342bc5-24ff-476c-a269-526b0b50870c": {
-      "templateId": "Quest:outpostquest_t1_l3",
-      "attributes": {
-        "level": -1,
-        "item_seen": true,
-        "sent_new_notification": true,
-        "challenge_bundle_id": "",
-        "xp_reward_scalar": 1,
-        "challenge_linked_quest_given": "",
-        "quest_pool": "",
-        "quest_state": "Claimed",
-        "last_state_change_time": "2020-01-26T18:56:50.401Z",
-        "challenge_linked_quest_parent": "",
-        "max_level_bonus": 0,
-        "completion_complete_outpost_1_3": 1,
-        "xp": 0,
-        "completion_custom_defendersupplyreceived": 1,
         "favorite": false
       },
       "quantity": 1
@@ -12991,17 +12525,6 @@
         "favorite": false
       },
       "quantity": 1
-    },
-    "dd46f79c-5191-4580-bb3c-53fe967fd235": {
-      "templateId": "AccountResource:reagent_traps",
-      "attributes": {
-        "max_level_bonus": 0,
-        "level": 1,
-        "item_seen": true,
-        "xp": 0,
-        "favorite": false
-      },
-      "quantity": 4990397
     },
     "ececc9a7-8f1d-4f32-8809-1396133ed6eb": {
       "templateId": "Quest:reactivequest_elemhusky",
@@ -27503,7 +27026,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27519,7 +27049,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27535,7 +27072,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27551,7 +27095,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27567,7 +27118,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27583,7 +27141,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27599,7 +27164,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27615,7 +27187,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27631,7 +27210,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27647,7 +27233,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27663,7 +27256,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27679,7 +27279,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27695,7 +27302,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27711,7 +27325,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27727,7 +27348,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27743,7 +27371,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27759,7 +27394,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27775,7 +27417,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27791,7 +27440,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27807,7 +27463,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27823,7 +27486,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27839,7 +27509,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27855,7 +27532,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27871,7 +27555,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27887,7 +27578,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27903,7 +27601,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27919,7 +27624,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27935,7 +27647,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27951,7 +27670,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27967,7 +27693,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27983,7 +27716,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -27999,7 +27739,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28015,7 +27762,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28031,7 +27785,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28047,7 +27808,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28063,7 +27831,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28079,7 +27854,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28095,7 +27877,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28111,7 +27900,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28127,7 +27923,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28143,7 +27946,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28159,7 +27969,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28175,7 +27992,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28191,7 +28015,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28207,7 +28038,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28223,7 +28061,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28239,7 +28084,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28255,7 +28107,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28271,7 +28130,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28287,7 +28153,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28303,7 +28176,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28319,7 +28199,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28335,7 +28222,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28351,7 +28245,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28367,7 +28268,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28383,7 +28291,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28399,7 +28314,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28415,7 +28337,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28431,7 +28360,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28447,7 +28383,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28463,7 +28406,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28479,7 +28429,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28495,7 +28452,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28511,7 +28475,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28527,7 +28498,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28543,7 +28521,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28559,7 +28544,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28575,7 +28567,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28591,7 +28590,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28607,7 +28613,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28623,7 +28636,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28639,7 +28659,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28655,7 +28682,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28671,7 +28705,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28687,7 +28728,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28703,7 +28751,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28719,7 +28774,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28735,7 +28797,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28751,7 +28820,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28767,7 +28843,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28783,7 +28866,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28799,7 +28889,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28815,7 +28912,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28831,7 +28935,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28847,7 +28958,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28863,7 +28981,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28879,7 +29004,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28895,7 +29027,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28911,7 +29050,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28927,7 +29073,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28943,7 +29096,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28959,7 +29119,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28975,7 +29142,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -28991,7 +29165,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29007,7 +29188,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29023,7 +29211,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29039,7 +29234,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29055,7 +29257,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29071,7 +29280,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29087,7 +29303,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29103,7 +29326,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29119,7 +29349,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29135,7 +29372,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29151,7 +29395,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29167,7 +29418,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29183,7 +29441,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29199,7 +29464,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29215,7 +29487,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29231,7 +29510,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29247,7 +29533,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29263,7 +29556,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29279,7 +29579,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29295,7 +29602,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29311,7 +29625,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29327,7 +29648,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29343,7 +29671,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29359,7 +29694,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29375,7 +29717,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29391,7 +29740,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29407,7 +29763,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29423,7 +29786,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29439,7 +29809,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29455,7 +29832,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29471,7 +29855,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29487,7 +29878,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29503,7 +29901,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29519,7 +29924,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29535,7 +29947,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29551,7 +29970,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29567,7 +29993,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29583,7 +30016,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29599,7 +30039,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29615,7 +30062,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29631,7 +30085,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29647,7 +30108,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29663,7 +30131,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29679,7 +30154,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29695,7 +30177,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29711,7 +30200,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29727,7 +30223,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29743,7 +30246,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29759,7 +30269,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29775,7 +30292,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29791,7 +30315,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29807,7 +30338,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29823,7 +30361,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29839,7 +30384,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29855,7 +30407,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29871,7 +30430,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29887,7 +30453,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29903,7 +30476,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29919,7 +30499,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29935,7 +30522,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29951,7 +30545,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29967,7 +30568,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29983,7 +30591,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -29999,7 +30614,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30015,7 +30637,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30031,7 +30660,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30047,7 +30683,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30063,7 +30706,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30079,7 +30729,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30095,7 +30752,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30111,7 +30775,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30127,7 +30798,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30143,7 +30821,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30159,7 +30844,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30175,7 +30867,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30191,7 +30890,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30207,7 +30913,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30223,7 +30936,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30239,7 +30959,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30255,7 +30982,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30271,7 +31005,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30287,7 +31028,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30303,7 +31051,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30319,7 +31074,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30335,7 +31097,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30351,7 +31120,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30367,7 +31143,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30383,7 +31166,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30399,7 +31189,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30415,7 +31212,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30431,7 +31235,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30447,7 +31258,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30463,7 +31281,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30479,7 +31304,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30495,7 +31327,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30511,7 +31350,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30527,7 +31373,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30543,7 +31396,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30559,7 +31419,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30575,7 +31442,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30591,7 +31465,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30607,7 +31488,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30623,7 +31511,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30639,7 +31534,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30655,7 +31557,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30671,7 +31580,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30687,7 +31603,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30703,7 +31626,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30719,7 +31649,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30735,7 +31672,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30751,7 +31695,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30767,7 +31718,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30783,7 +31741,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30799,7 +31764,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30815,7 +31787,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30831,7 +31810,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30847,7 +31833,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30863,7 +31856,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30879,7 +31879,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30895,7 +31902,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30911,7 +31925,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30927,7 +31948,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30943,7 +31971,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30959,7 +31994,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30975,7 +32017,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -30991,7 +32040,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31007,7 +32063,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31023,7 +32086,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31039,7 +32109,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31055,7 +32132,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31071,7 +32155,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31087,7 +32178,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31103,7 +32201,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31119,7 +32224,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31135,7 +32247,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31151,7 +32270,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31167,7 +32293,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31183,7 +32316,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31199,7 +32339,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31215,7 +32362,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31231,7 +32385,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31247,7 +32408,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31263,7 +32431,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31279,7 +32454,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31295,7 +32477,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31311,7 +32500,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31327,7 +32523,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31343,7 +32546,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31359,7 +32569,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31375,7 +32592,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31391,7 +32615,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31407,7 +32638,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31423,7 +32661,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31439,7 +32684,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31455,7 +32707,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31471,7 +32730,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31487,7 +32753,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31503,7 +32776,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31519,7 +32799,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31535,7 +32822,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31551,7 +32845,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31567,7 +32868,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31583,7 +32891,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31599,7 +32914,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31615,7 +32937,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31631,7 +32960,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31647,7 +32983,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31663,7 +33006,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31679,7 +33029,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31695,7 +33052,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31711,7 +33075,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31727,7 +33098,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31743,7 +33121,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31759,7 +33144,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31775,7 +33167,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31791,7 +33190,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31807,7 +33213,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31823,7 +33236,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31839,7 +33259,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31855,7 +33282,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31871,7 +33305,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31887,7 +33328,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31903,7 +33351,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31919,7 +33374,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31935,7 +33397,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31951,7 +33420,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31967,7 +33443,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31983,7 +33466,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -31999,7 +33489,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32015,7 +33512,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32031,7 +33535,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32047,7 +33558,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32063,7 +33581,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32079,7 +33604,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32095,7 +33627,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32111,7 +33650,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32127,7 +33673,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32143,7 +33696,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32159,7 +33719,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32175,7 +33742,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32191,7 +33765,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32207,7 +33788,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32223,7 +33811,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32239,7 +33834,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32255,7 +33857,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32271,7 +33880,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32287,7 +33903,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32303,7 +33926,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32319,7 +33949,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32335,7 +33972,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32351,7 +33995,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32367,7 +34018,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32383,7 +34041,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32399,7 +34064,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32415,7 +34087,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32431,7 +34110,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32447,7 +34133,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32463,7 +34156,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32479,7 +34179,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32495,7 +34202,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32511,7 +34225,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32527,7 +34248,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32543,7 +34271,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32559,7 +34294,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32575,7 +34317,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32591,7 +34340,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32607,7 +34363,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32623,7 +34386,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32639,7 +34409,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32655,7 +34432,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32671,7 +34455,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32687,7 +34478,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32703,7 +34501,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32719,7 +34524,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32735,7 +34547,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32751,7 +34570,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32767,7 +34593,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32783,7 +34616,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32799,7 +34639,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32815,7 +34662,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32831,7 +34685,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32847,7 +34708,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32863,7 +34731,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32879,7 +34754,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32895,7 +34777,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32911,7 +34800,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32927,7 +34823,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32943,7 +34846,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32959,7 +34869,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32975,7 +34892,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -32991,7 +34915,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33007,7 +34938,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33023,7 +34961,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33039,7 +34984,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33055,7 +35007,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33071,7 +35030,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33087,7 +35053,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33103,7 +35076,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33119,7 +35099,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33135,7 +35122,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33151,7 +35145,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33167,7 +35168,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33183,7 +35191,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33199,7 +35214,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33215,7 +35237,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33231,7 +35260,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33247,7 +35283,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33263,7 +35306,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33279,7 +35329,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33295,7 +35352,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33311,7 +35375,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33327,7 +35398,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33343,7 +35421,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33359,7 +35444,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33375,7 +35467,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33391,7 +35490,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33407,7 +35513,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33423,7 +35536,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33439,7 +35559,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33455,7 +35582,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33471,7 +35605,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33487,7 +35628,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33503,7 +35651,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33519,7 +35674,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33535,7 +35697,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33551,7 +35720,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33567,7 +35743,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33583,7 +35766,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33599,7 +35789,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33615,7 +35812,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33631,7 +35835,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33647,7 +35858,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33663,7 +35881,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33679,7 +35904,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33695,7 +35927,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33711,7 +35950,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33727,7 +35973,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33743,7 +35996,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33759,7 +36019,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33775,7 +36042,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33791,7 +36065,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33807,7 +36088,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33823,7 +36111,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33839,7 +36134,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33855,7 +36157,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33871,7 +36180,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33887,7 +36203,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33903,7 +36226,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33919,7 +36249,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33935,7 +36272,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33951,7 +36295,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33967,7 +36318,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33983,7 +36341,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -33999,7 +36364,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34015,7 +36387,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34031,7 +36410,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34047,7 +36433,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34063,7 +36456,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34079,7 +36479,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34095,7 +36502,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34111,7 +36525,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34127,7 +36548,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34143,7 +36571,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34159,7 +36594,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34175,7 +36617,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34191,7 +36640,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34207,7 +36663,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34223,7 +36686,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34239,7 +36709,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34255,7 +36732,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34271,7 +36755,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34287,7 +36778,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34303,7 +36801,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34319,7 +36824,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34335,7 +36847,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34351,7 +36870,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34367,7 +36893,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34383,7 +36916,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34399,7 +36939,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34415,7 +36962,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34431,7 +36985,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34447,7 +37008,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34463,7 +37031,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34479,7 +37054,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34495,7 +37077,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34511,7 +37100,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34527,7 +37123,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34543,7 +37146,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34559,7 +37169,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34575,7 +37192,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34591,7 +37215,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34607,7 +37238,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34623,7 +37261,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34639,7 +37284,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34655,7 +37307,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34671,7 +37330,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34687,7 +37353,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34703,7 +37376,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34719,7 +37399,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34735,7 +37422,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34751,7 +37445,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34767,7 +37468,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34783,7 +37491,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34799,7 +37514,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34815,7 +37537,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34831,7 +37560,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34847,7 +37583,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34863,7 +37606,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34879,7 +37629,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34895,7 +37652,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34911,7 +37675,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34927,7 +37698,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34943,7 +37721,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34959,7 +37744,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34975,7 +37767,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -34991,7 +37790,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35007,7 +37813,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35023,7 +37836,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35039,7 +37859,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35055,7 +37882,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35071,7 +37905,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35087,7 +37928,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35103,7 +37951,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35119,7 +37974,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35135,7 +37997,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35151,7 +38020,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35167,7 +38043,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35183,7 +38066,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35199,7 +38089,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35215,7 +38112,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35231,7 +38135,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35247,7 +38158,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35263,7 +38181,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35279,7 +38204,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35295,7 +38227,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35311,7 +38250,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35327,7 +38273,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35343,7 +38296,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35359,7 +38319,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35375,7 +38342,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35391,7 +38365,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35407,7 +38388,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35423,7 +38411,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35439,7 +38434,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35455,7 +38457,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35471,7 +38480,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35487,7 +38503,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35503,7 +38526,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35519,7 +38549,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35535,7 +38572,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35551,7 +38595,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35567,7 +38618,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35583,7 +38641,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35599,7 +38664,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35615,7 +38687,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35631,7 +38710,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35647,7 +38733,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35663,7 +38756,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35679,7 +38779,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35695,7 +38802,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35711,7 +38825,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35727,7 +38848,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35743,7 +38871,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35759,7 +38894,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35775,7 +38917,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35791,7 +38940,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35807,7 +38963,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35823,7 +38986,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35839,7 +39009,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35855,7 +39032,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35871,7 +39055,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35887,7 +39078,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35903,7 +39101,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35919,7 +39124,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35935,7 +39147,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35951,7 +39170,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35967,7 +39193,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35983,7 +39216,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -35999,7 +39239,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36015,7 +39262,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36031,7 +39285,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36047,7 +39308,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36063,7 +39331,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36079,7 +39354,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36095,7 +39377,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36111,7 +39400,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36127,7 +39423,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36143,7 +39446,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36159,7 +39469,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36175,7 +39492,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36191,7 +39515,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36207,7 +39538,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36223,7 +39561,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36239,7 +39584,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36255,7 +39607,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36271,7 +39630,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36287,7 +39653,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36303,7 +39676,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36319,7 +39699,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36335,7 +39722,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36351,7 +39745,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36367,7 +39768,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36383,7 +39791,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36399,7 +39814,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36415,7 +39837,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36431,7 +39860,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36447,7 +39883,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36463,7 +39906,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36479,7 +39929,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36495,7 +39952,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36511,7 +39975,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36527,7 +39998,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36543,7 +40021,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36559,7 +40044,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36575,7 +40067,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36591,7 +40090,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36607,7 +40113,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36623,7 +40136,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36639,7 +40159,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36655,7 +40182,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36671,7 +40205,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36687,7 +40228,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36703,7 +40251,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36719,7 +40274,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36735,7 +40297,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36751,7 +40320,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36767,7 +40343,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36783,7 +40366,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36799,7 +40389,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36815,7 +40412,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36831,7 +40435,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36847,7 +40458,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36863,7 +40481,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36879,7 +40504,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36895,7 +40527,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36911,7 +40550,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36927,7 +40573,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36943,7 +40596,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36959,7 +40619,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36975,7 +40642,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -36991,7 +40665,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37007,7 +40688,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37023,7 +40711,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37039,7 +40734,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37055,7 +40757,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37071,7 +40780,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37087,7 +40803,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37103,7 +40826,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37119,7 +40849,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37135,7 +40872,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37151,7 +40895,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37167,7 +40918,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37183,7 +40941,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37199,7 +40964,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37215,7 +40987,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37231,7 +41010,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37247,7 +41033,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37263,7 +41056,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37279,7 +41079,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37295,7 +41102,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37311,7 +41125,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37327,7 +41148,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37343,7 +41171,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37359,7 +41194,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37375,7 +41217,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37391,7 +41240,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37407,7 +41263,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37423,7 +41286,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37439,7 +41309,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37455,7 +41332,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37471,7 +41355,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37487,7 +41378,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37503,7 +41401,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37519,7 +41424,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37535,7 +41447,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37551,7 +41470,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37567,7 +41493,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37583,7 +41516,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37599,7 +41539,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37615,7 +41562,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37631,7 +41585,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37647,7 +41608,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37663,7 +41631,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37679,7 +41654,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37695,7 +41677,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37711,7 +41700,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37727,7 +41723,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37743,7 +41746,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37759,7 +41769,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37775,7 +41792,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37791,7 +41815,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37807,7 +41838,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37823,7 +41861,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37839,7 +41884,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37855,7 +41907,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37871,7 +41930,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37887,7 +41953,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37903,7 +41976,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37919,7 +41999,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37935,7 +42022,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37951,7 +42045,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37967,7 +42068,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37983,7 +42091,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -37999,7 +42114,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38015,7 +42137,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38031,7 +42160,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38047,7 +42183,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38063,7 +42206,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38079,7 +42229,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38095,7 +42252,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38111,7 +42275,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38127,7 +42298,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38143,7 +42321,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38159,7 +42344,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38175,7 +42367,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38191,7 +42390,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38207,7 +42413,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38223,7 +42436,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38239,7 +42459,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38255,7 +42482,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38271,7 +42505,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38287,7 +42528,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38303,7 +42551,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38319,7 +42574,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38335,7 +42597,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38351,7 +42620,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38367,7 +42643,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38383,7 +42666,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38399,7 +42689,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38415,7 +42712,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38431,7 +42735,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38447,7 +42758,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38463,7 +42781,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38479,7 +42804,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38495,7 +42827,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38511,7 +42850,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38527,7 +42873,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38543,7 +42896,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38559,7 +42919,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38575,7 +42942,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38591,7 +42965,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38607,7 +42988,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38623,7 +43011,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38639,7 +43034,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38655,7 +43057,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38671,7 +43080,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38687,7 +43103,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38703,7 +43126,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38719,7 +43149,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38735,7 +43172,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38751,7 +43195,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38767,7 +43218,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38783,7 +43241,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38799,7 +43264,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38815,7 +43287,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38831,7 +43310,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38847,7 +43333,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38863,7 +43356,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38879,7 +43379,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38895,7 +43402,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38911,7 +43425,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38927,7 +43448,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38943,7 +43471,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38959,7 +43494,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38975,7 +43517,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -38991,7 +43540,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39007,7 +43563,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39023,7 +43586,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39039,7 +43609,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39055,7 +43632,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39071,7 +43655,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39087,7 +43678,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39103,7 +43701,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39119,7 +43724,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39135,7 +43747,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39151,7 +43770,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39167,7 +43793,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39183,7 +43816,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39199,7 +43839,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39215,7 +43862,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39231,7 +43885,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39247,7 +43908,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39263,7 +43931,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39279,7 +43954,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39295,7 +43977,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39311,7 +44000,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39327,7 +44023,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39343,7 +44046,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39359,7 +44069,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39375,7 +44092,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39391,7 +44115,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39407,7 +44138,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39423,7 +44161,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39439,7 +44184,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39455,7 +44207,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39471,7 +44230,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39487,7 +44253,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39503,7 +44276,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39519,7 +44299,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39535,7 +44322,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39551,7 +44345,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39567,7 +44368,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39583,7 +44391,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39599,7 +44414,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39615,7 +44437,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39631,7 +44460,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39647,7 +44483,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39663,7 +44506,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39679,7 +44529,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39695,7 +44552,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39711,7 +44575,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39727,7 +44598,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39743,7 +44621,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39759,7 +44644,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39775,7 +44667,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39791,7 +44690,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39807,7 +44713,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39823,7 +44736,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39839,7 +44759,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39855,7 +44782,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39871,7 +44805,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39887,7 +44828,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39903,7 +44851,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39919,7 +44874,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39935,7 +44897,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39951,7 +44920,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39967,7 +44943,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39983,7 +44966,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -39999,7 +44989,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40015,7 +45012,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40031,7 +45035,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40047,7 +45058,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40063,7 +45081,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40079,7 +45104,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40095,7 +45127,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40111,7 +45150,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40127,7 +45173,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40143,7 +45196,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40159,7 +45219,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40175,7 +45242,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40191,7 +45265,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40207,7 +45288,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40223,7 +45311,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40239,7 +45334,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40255,7 +45357,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40271,7 +45380,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40287,7 +45403,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40303,7 +45426,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40319,7 +45449,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40335,7 +45472,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40351,7 +45495,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40367,7 +45518,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40383,7 +45541,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40399,7 +45564,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40415,7 +45587,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40431,7 +45610,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40447,7 +45633,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40463,7 +45656,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40479,7 +45679,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40495,7 +45702,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40511,7 +45725,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40527,7 +45748,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40543,7 +45771,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40559,7 +45794,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40575,7 +45817,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40591,7 +45840,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40607,7 +45863,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40623,7 +45886,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40639,7 +45909,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40655,7 +45932,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40671,7 +45955,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40687,7 +45978,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40703,7 +46001,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40719,7 +46024,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40735,7 +46047,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40751,7 +46070,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40767,7 +46093,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40783,7 +46116,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40799,7 +46139,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40815,7 +46162,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40831,7 +46185,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40847,7 +46208,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40863,7 +46231,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40879,7 +46254,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40895,7 +46277,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40911,7 +46300,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40927,7 +46323,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40943,7 +46346,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40959,7 +46369,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40975,7 +46392,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -40991,7 +46415,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41007,7 +46438,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41023,7 +46461,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41039,7 +46484,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41055,7 +46507,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41071,7 +46530,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41087,7 +46553,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41103,7 +46576,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41119,7 +46599,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41135,7 +46622,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41151,7 +46645,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41167,7 +46668,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41183,7 +46691,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41199,7 +46714,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41215,7 +46737,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41231,7 +46760,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41247,7 +46783,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41263,7 +46806,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41279,7 +46829,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41295,7 +46852,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41311,7 +46875,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41327,7 +46898,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41343,7 +46921,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41359,7 +46944,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41375,7 +46967,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41391,7 +46990,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41407,7 +47013,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41423,7 +47036,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41439,7 +47059,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41455,7 +47082,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41471,7 +47105,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41487,7 +47128,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41503,7 +47151,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41519,7 +47174,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41535,7 +47197,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41551,7 +47220,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41567,7 +47243,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41583,7 +47266,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41599,7 +47289,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41615,7 +47312,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41631,7 +47335,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41647,7 +47358,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41663,7 +47381,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41679,7 +47404,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41695,7 +47427,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41711,7 +47450,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41727,7 +47473,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41743,7 +47496,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41759,7 +47519,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41775,7 +47542,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41791,7 +47565,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41807,7 +47588,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41823,7 +47611,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41839,7 +47634,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41855,7 +47657,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41871,7 +47680,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41887,7 +47703,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41903,7 +47726,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41919,7 +47749,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41935,7 +47772,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41951,7 +47795,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41967,7 +47818,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41983,7 +47841,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -41999,7 +47864,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42015,7 +47887,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42031,7 +47910,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42047,7 +47933,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42063,7 +47956,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42079,7 +47979,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42095,7 +48002,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42111,7 +48025,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42127,7 +48048,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42143,7 +48071,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42159,7 +48094,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42175,7 +48117,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42191,7 +48140,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42207,7 +48163,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42223,7 +48186,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42239,7 +48209,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42255,7 +48232,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42271,7 +48255,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42287,7 +48278,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42303,7 +48301,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42319,7 +48324,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42335,7 +48347,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42351,7 +48370,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42367,7 +48393,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42383,7 +48416,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42399,7 +48439,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42415,7 +48462,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42431,7 +48485,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42447,7 +48508,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42463,7 +48531,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42479,7 +48554,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42495,7 +48577,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42511,7 +48600,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42527,7 +48623,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42543,7 +48646,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42559,7 +48669,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42575,7 +48692,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42591,7 +48715,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42607,7 +48738,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42623,7 +48761,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42639,7 +48784,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42655,7 +48807,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42671,7 +48830,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42687,7 +48853,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42703,7 +48876,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42719,7 +48899,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42735,7 +48922,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42751,7 +48945,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42767,7 +48968,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42783,7 +48991,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42799,7 +49014,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42815,7 +49037,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42831,7 +49060,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42847,7 +49083,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42863,7 +49106,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42879,7 +49129,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42895,7 +49152,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42911,7 +49175,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42927,7 +49198,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42943,7 +49221,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42959,7 +49244,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42975,7 +49267,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -42991,7 +49290,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43007,7 +49313,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43023,7 +49336,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43039,7 +49359,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43055,7 +49382,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43071,7 +49405,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43087,7 +49428,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43103,7 +49451,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43119,7 +49474,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43135,7 +49497,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43151,7 +49520,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43167,7 +49543,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43183,7 +49566,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43199,7 +49589,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43215,7 +49612,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43231,7 +49635,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43247,7 +49658,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43263,7 +49681,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43279,7 +49704,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43295,7 +49727,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43311,7 +49750,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43327,7 +49773,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43343,7 +49796,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43359,7 +49819,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43375,7 +49842,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43391,7 +49865,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43407,7 +49888,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43423,7 +49911,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43439,7 +49934,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43455,7 +49957,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43471,7 +49980,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43487,7 +50003,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43503,7 +50026,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43519,7 +50049,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43535,7 +50072,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43551,7 +50095,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43567,7 +50118,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43583,7 +50141,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43599,7 +50164,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43615,7 +50187,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43631,7 +50210,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43647,7 +50233,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43663,7 +50256,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43679,7 +50279,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43695,7 +50302,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43711,7 +50325,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43727,7 +50348,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43743,7 +50371,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43759,7 +50394,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43775,7 +50417,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43791,7 +50440,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43807,7 +50463,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43823,7 +50486,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43839,7 +50509,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43855,7 +50532,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43871,7 +50555,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43887,7 +50578,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43903,7 +50601,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43919,7 +50624,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43935,7 +50647,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43951,7 +50670,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43967,7 +50693,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43983,7 +50716,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -43999,7 +50739,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44015,7 +50762,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44031,7 +50785,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44047,7 +50808,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44063,7 +50831,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44079,7 +50854,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44095,7 +50877,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44111,7 +50900,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44127,7 +50923,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44143,7 +50946,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44159,7 +50969,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44175,7 +50992,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44191,7 +51015,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44207,7 +51038,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44223,7 +51061,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44239,7 +51084,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44255,7 +51107,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44271,7 +51130,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44287,7 +51153,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44303,7 +51176,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44319,7 +51199,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44335,7 +51222,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44351,7 +51245,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44367,7 +51268,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44383,7 +51291,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44399,7 +51314,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44415,7 +51337,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44431,7 +51360,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44447,7 +51383,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44463,7 +51406,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44479,7 +51429,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44495,7 +51452,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44511,7 +51475,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44527,7 +51498,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44543,7 +51521,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44559,7 +51544,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44575,7 +51567,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44591,7 +51590,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44607,7 +51613,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44623,7 +51636,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44639,7 +51659,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44655,7 +51682,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44671,7 +51705,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44687,7 +51728,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44703,7 +51751,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44719,7 +51774,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44735,7 +51797,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44751,7 +51820,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44767,7 +51843,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44783,7 +51866,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44799,7 +51889,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44815,7 +51912,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44831,7 +51935,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44847,7 +51958,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44863,7 +51981,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44879,7 +52004,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44895,7 +52027,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44911,7 +52050,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44927,7 +52073,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44943,7 +52096,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44959,7 +52119,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44975,7 +52142,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -44991,7 +52165,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45007,7 +52188,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45023,7 +52211,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45039,7 +52234,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45055,7 +52257,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45071,7 +52280,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45087,7 +52303,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45103,7 +52326,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45119,7 +52349,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45135,7 +52372,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45151,7 +52395,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45167,7 +52418,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45183,7 +52441,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45199,7 +52464,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45215,7 +52487,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45231,7 +52510,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45247,7 +52533,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45263,7 +52556,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45279,7 +52579,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45295,7 +52602,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45311,7 +52625,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45327,7 +52648,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45343,7 +52671,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45359,7 +52694,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45375,7 +52717,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45391,7 +52740,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45407,7 +52763,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45423,7 +52786,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45439,7 +52809,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45455,7 +52832,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45471,7 +52855,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45487,7 +52878,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45503,7 +52901,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45519,7 +52924,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45535,7 +52947,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45551,7 +52970,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45567,7 +52993,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45583,7 +53016,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45599,7 +53039,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45615,7 +53062,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45631,7 +53085,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45647,7 +53108,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45663,7 +53131,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45679,7 +53154,14 @@
         "level": 30,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45695,7 +53177,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45711,7 +53200,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45727,7 +53223,14 @@
         "level": 20,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45743,7 +53246,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45759,7 +53269,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45775,7 +53292,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45791,7 +53315,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45807,7 +53338,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45823,7 +53361,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45839,7 +53384,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45855,7 +53407,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45871,7 +53430,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45887,7 +53453,14 @@
         "level": 50,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45903,7 +53476,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45919,7 +53499,14 @@
         "level": 40,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45935,7 +53522,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45951,7 +53545,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45967,7 +53568,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45983,7 +53591,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -45999,7 +53614,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -46015,7 +53637,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -46031,7 +53660,14 @@
         "level": 1,
         "refund_legacy_item": false,
         "item_seen": true,
-        "alterations": [],
+        "alterations": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ],
         "xp": 0,
         "refundable": false,
         "alteration_base_rarities": [],
@@ -47496,6 +55132,2279 @@
         ]
       },
       "quantity": 1
+    },
+    "Quest:outpostquest_t1_l1": {
+      "templateId": "Quest:outpostquest_t1_l1",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "completion_custom_supplydropreceived": 1,
+        "completion_complete_outpost_1_1": 1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "completion_custom_deployoutpost": 1,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-21T13:45:24.247Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l2": {
+      "templateId": "Quest:outpostquest_t1_l2",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-21T15:37:01.947Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_1_2": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l3": {
+      "templateId": "Quest:outpostquest_t1_l3",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-21T17:14:01.473Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "completion_complete_outpost_1_3": 1,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l4": {
+      "templateId": "Quest:outpostquest_t1_l4",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-23T13:41:57.009Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_1_4": 1,
+        "quest_rarity": "uncommon",
+        "completion_custom_defendersupplyreceived": 1,
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l5": {
+      "templateId": "Quest:outpostquest_t1_l5",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-25T14:42:11.295Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_1_5": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l6": {
+      "templateId": "Quest:outpostquest_t1_l6",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T07:43:42.708Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "completion_complete_outpost_1_6": 1,
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l7": {
+      "templateId": "Quest:outpostquest_t1_l7",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T09:17:18.893Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_1_7": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l8": {
+      "templateId": "Quest:outpostquest_t1_l8",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T10:12:11.791Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false,
+        "completion_complete_outpost_1_8": 1
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l9": {
+      "templateId": "Quest:outpostquest_t1_l9",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T10:57:09.344Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false,
+        "completion_complete_outpost_1_9": 1
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_l10": {
+      "templateId": "Quest:outpostquest_t1_l10",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "completion_complete_outpost_1_10": 1,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T11:35:40.261Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t1_endless": {
+      "templateId": "Quest:outpostquest_t1_endless",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "completion_complete_outpost_1_endless": 0,
+        "quest_state": "Active",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T11:35:40.264Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l1": {
+      "templateId": "Quest:outpostquest_t2_l1",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_custom_plankdeployoutpost": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T13:57:03.465Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_2_1": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l2": {
+      "templateId": "Quest:outpostquest_t2_l2",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T20:07:12.034Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "completion_complete_outpost_2_2": 1,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l3": {
+      "templateId": "Quest:outpostquest_t2_l3",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-09T15:47:26.883Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_2_3": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l4": {
+      "templateId": "Quest:outpostquest_t2_l4",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-10T10:52:40.398Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_2_4": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l5": {
+      "templateId": "Quest:outpostquest_t2_l5",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-10T19:05:12.712Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "completion_complete_outpost_2_5": 1,
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l6": {
+      "templateId": "Quest:outpostquest_t2_l6",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-10T20:46:26.147Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_2_6": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l7": {
+      "templateId": "Quest:outpostquest_t2_l7",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-16T14:10:07.281Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false,
+        "completion_complete_outpost_2_7": 1
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l8": {
+      "templateId": "Quest:outpostquest_t2_l8",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-25T16:01:16.591Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false,
+        "completion_complete_outpost_2_8": 1
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l9": {
+      "templateId": "Quest:outpostquest_t2_l9",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-01T15:42:38.342Z",
+        "completion_complete_outpost_2_9": 1,
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_l10": {
+      "templateId": "Quest:outpostquest_t2_l10",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "completion_complete_outpost_2_10": 1,
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-01T16:58:09.093Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t2_endless": {
+      "templateId": "Quest:outpostquest_t2_endless",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Active",
+        "bucket": "",
+        "last_state_change_time": "2019-12-01T16:58:09.095Z",
+        "completion_complete_outpost_2_endless": 0,
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l1": {
+      "templateId": "Quest:outpostquest_t3_l1",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-16T12:13:06.057Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "completion_complete_outpost_3_1": 1,
+        "xp": 0,
+        "completion_custom_cannydeployoutpost": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l2": {
+      "templateId": "Quest:outpostquest_t3_l2",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-02T16:37:35.118Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_3_2": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l3": {
+      "templateId": "Quest:outpostquest_t3_l3",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-07T08:13:33.307Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_3_3": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l4": {
+      "templateId": "Quest:outpostquest_t3_l4",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-07T08:36:40.401Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "completion_complete_outpost_3_4": 1,
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l5": {
+      "templateId": "Quest:outpostquest_t3_l5",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-07T08:56:28.282Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_3_5": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l6": {
+      "templateId": "Quest:outpostquest_t3_l6",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-08T13:17:58.981Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false,
+        "completion_complete_outpost_3_6": 1
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l7": {
+      "templateId": "Quest:outpostquest_t3_l7",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-15T12:01:00.118Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false,
+        "completion_complete_outpost_3_7": 1
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l8": {
+      "templateId": "Quest:outpostquest_t3_l8",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-15T12:36:50.544Z",
+        "completion_complete_outpost_3_8": 1,
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l9": {
+      "templateId": "Quest:outpostquest_t3_l9",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "completion_complete_outpost_3_9": 1,
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-15T13:06:06.512Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_l10": {
+      "templateId": "Quest:outpostquest_t3_l10",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-15T13:47:16.025Z",
+        "completion_complete_outpost_3_10": 1,
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t3_endless": {
+      "templateId": "Quest:outpostquest_t3_endless",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Active",
+        "bucket": "",
+        "last_state_change_time": "2019-12-15T13:47:16.030Z",
+        "challenge_linked_quest_parent": "",
+        "completion_complete_outpost_3_endless": 0,
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t4_l1": {
+      "templateId": "Quest:outpostquest_t4_l1",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-19T11:56:37.628Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_4_1": 1,
+        "completion_custom_twinedeployoutpost": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t4_l2": {
+      "templateId": "Quest:outpostquest_t4_l2",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-19T13:23:16.961Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_4_2": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t4_l3": {
+      "templateId": "Quest:outpostquest_t4_l3",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-19T13:58:12.505Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "completion_complete_outpost_4_3": 1,
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t4_l4": {
+      "templateId": "Quest:outpostquest_t4_l4",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": false,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-19T15:02:57.127Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "completion_complete_outpost_4_4": 1,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:outpostquest_t4_l5": {
+      "templateId": "Quest:outpostquest_t4_l5",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-19T16:17:04.872Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false,
+        "completion_complete_outpost_4_5": 1
+      },
+      "quantity": 1
+    },
+    "Quest:plankertonquest_outpost_l2": {
+      "templateId": "Quest:plankertonquest_outpost_l2",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t2_l2": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-10-26T20:07:14.072Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:plankertonquest_outpost_l3": {
+      "templateId": "Quest:plankertonquest_outpost_l3",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "completion_questcomplete_outpostquest_t2_l3": 1,
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-09T15:47:33.440Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:plankertonquest_outpost_l4": {
+      "templateId": "Quest:plankertonquest_outpost_l4",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "completion_questcomplete_outpostquest_t2_l4": 1,
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-10T17:33:21.112Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:plankertonquest_outpost_l5": {
+      "templateId": "Quest:plankertonquest_outpost_l5",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "completion_questcomplete_outpostquest_t2_l5": 1,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-11-30T16:45:03.942Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:plankertonquest_outpost_l6": {
+      "templateId": "Quest:plankertonquest_outpost_l6",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "completion_questcomplete_outpostquest_t2_l6": 1,
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2019-12-27T16:50:46.976Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:cannyvalleyquest_outpost_l2": {
+      "templateId": "Quest:cannyvalleyquest_outpost_l2",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t3_l2": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:cannyvalleyquest_outpost_l3": {
+      "templateId": "Quest:cannyvalleyquest_outpost_l3",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t3_l3": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:cannyvalleyquest_outpost_l4": {
+      "templateId": "Quest:cannyvalleyquest_outpost_l4",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t3_l4": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:cannyvalleyquest_outpost_l5": {
+      "templateId": "Quest:cannyvalleyquest_outpost_l5",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t3_l5": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:cannyvalleyquest_outpost_l6": {
+      "templateId": "Quest:cannyvalleyquest_outpost_l6",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t3_l6": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:twinepeaksquest_outpost_l2": {
+      "templateId": "Quest:twinepeaksquest_outpost_l2",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t4_l2": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:twinepeaksquest_outpost_l3": {
+      "templateId": "Quest:twinepeaksquest_outpost_l3",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t4_l3": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:twinepeaksquest_outpost_l4": {
+      "templateId": "Quest:twinepeaksquest_outpost_l4",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t4_l4": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "Quest:twinepeaksquest_outpost_l5": {
+      "templateId": "Quest:twinepeaksquest_outpost_l5",
+      "attributes": {
+        "creation_time": "min",
+        "level": -1,
+        "item_seen": true,
+        "playlists": [],
+        "completion_questcomplete_outpostquest_t4_l5": 1,
+        "sent_new_notification": true,
+        "challenge_bundle_id": "",
+        "xp_reward_scalar": 1,
+        "challenge_linked_quest_given": "",
+        "quest_pool": "",
+        "quest_state": "Claimed",
+        "bucket": "",
+        "last_state_change_time": "2020-01-01T17:08:00.666Z",
+        "challenge_linked_quest_parent": "",
+        "max_level_bonus": 0,
+        "xp": 0,
+        "quest_rarity": "uncommon",
+        "favorite": false
+      },
+      "quantity": 1
+    },
+    "e7937131-d261-47bb-af93-b64b813ae8b7": {
+      "templateId": "HomebaseNode:questreward_evolution4",
+      "attributes": {
+        "item_seen": true
+      },
+      "quantity": 1
+    },
+    "AccountResource:Campaign_Event_Currency": {
+      "templateId": "AccountResource:Campaign_Event_Currency",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Currency_MtxSwap": {
+      "templateId": "AccountResource:Currency_MtxSwap",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Currency_XRayLlama": {
+      "templateId": "AccountResource:Currency_XRayLlama",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Adventure": {
+      "templateId": "AccountResource:EventCurrency_Adventure",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Blockbuster": {
+      "templateId": "AccountResource:EventCurrency_Blockbuster",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Candy": {
+      "templateId": "AccountResource:EventCurrency_Candy",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Founders": {
+      "templateId": "AccountResource:EventCurrency_Founders",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Lunar": {
+      "templateId": "AccountResource:EventCurrency_Lunar",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_PumpkinWarhead": {
+      "templateId": "AccountResource:EventCurrency_PumpkinWarhead",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_RoadTrip": {
+      "templateId": "AccountResource:EventCurrency_RoadTrip",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Scaling": {
+      "templateId": "AccountResource:EventCurrency_Scaling",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Scavenger": {
+      "templateId": "AccountResource:EventCurrency_Scavenger",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Snowballs": {
+      "templateId": "AccountResource:EventCurrency_Snowballs",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Spring": {
+      "templateId": "AccountResource:EventCurrency_Spring",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_StormZone": {
+      "templateId": "AccountResource:EventCurrency_StormZone",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:EventCurrency_Summer": {
+      "templateId": "AccountResource:EventCurrency_Summer",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:HeroXP": {
+      "templateId": "AccountResource:HeroXP",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:PeopleResource": {
+      "templateId": "AccountResource:PeopleResource",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:PersonnelXP": {
+      "templateId": "AccountResource:PersonnelXP",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:PhoenixXP": {
+      "templateId": "AccountResource:PhoenixXP",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Ele_Fire": {
+      "templateId": "AccountResource:Reagent_Alteration_Ele_Fire",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Ele_Nature": {
+      "templateId": "AccountResource:Reagent_Alteration_Ele_Nature",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Ele_Water": {
+      "templateId": "AccountResource:Reagent_Alteration_Ele_Water",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Gameplay_Generic": {
+      "templateId": "AccountResource:Reagent_Alteration_Gameplay_Generic",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Generic": {
+      "templateId": "AccountResource:Reagent_Alteration_Generic",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Upgrade_R": {
+      "templateId": "AccountResource:Reagent_Alteration_Upgrade_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Upgrade_SR": {
+      "templateId": "AccountResource:Reagent_Alteration_Upgrade_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Upgrade_UC": {
+      "templateId": "AccountResource:Reagent_Alteration_Upgrade_UC",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Alteration_Upgrade_VR": {
+      "templateId": "AccountResource:Reagent_Alteration_Upgrade_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_C_T01": {
+      "templateId": "AccountResource:Reagent_C_T01",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_C_T02": {
+      "templateId": "AccountResource:Reagent_C_T02",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_C_T03": {
+      "templateId": "AccountResource:Reagent_C_T03",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_C_T04": {
+      "templateId": "AccountResource:Reagent_C_T04",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_EvolveRarity_R": {
+      "templateId": "AccountResource:Reagent_EvolveRarity_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_EvolveRarity_SR": {
+      "templateId": "AccountResource:Reagent_EvolveRarity_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_EvolveRarity_VR": {
+      "templateId": "AccountResource:Reagent_EvolveRarity_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_People": {
+      "templateId": "AccountResource:Reagent_People",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Promotion_Heroes": {
+      "templateId": "AccountResource:Reagent_Promotion_Heroes",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Promotion_Survivors": {
+      "templateId": "AccountResource:Reagent_Promotion_Survivors",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Promotion_Traps": {
+      "templateId": "AccountResource:Reagent_Promotion_Traps",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Promotion_Weapons": {
+      "templateId": "AccountResource:Reagent_Promotion_Weapons",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Traps": {
+      "templateId": "AccountResource:Reagent_Traps",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Reagent_Weapons": {
+      "templateId": "AccountResource:Reagent_Weapons",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:SchematicXP": {
+      "templateId": "AccountResource:SchematicXP",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:SpecialCurrency_Daily": {
+      "templateId": "AccountResource:SpecialCurrency_Daily",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_BasicPack": {
+      "templateId": "AccountResource:Voucher_BasicPack",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_CardPack_2021Anniversary": {
+      "templateId": "AccountResource:Voucher_CardPack_2021Anniversary",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_CardPack_Bronze": {
+      "templateId": "AccountResource:Voucher_CardPack_Bronze",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_CardPack_Jackpot": {
+      "templateId": "AccountResource:Voucher_CardPack_Jackpot",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Custom_Firecracker_R": {
+      "templateId": "AccountResource:Voucher_Custom_Firecracker_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Constructor_Bundle": {
+      "templateId": "AccountResource:Voucher_Founders_Constructor_Bundle",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Constructor_Weapon_SR": {
+      "templateId": "AccountResource:Voucher_Founders_Constructor_Weapon_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Constructor_Weapon_VR": {
+      "templateId": "AccountResource:Voucher_Founders_Constructor_Weapon_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Ninja_Bundle": {
+      "templateId": "AccountResource:Voucher_Founders_Ninja_Bundle",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Ninja_Weapon_SR": {
+      "templateId": "AccountResource:Voucher_Founders_Ninja_Weapon_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Ninja_Weapon_VR": {
+      "templateId": "AccountResource:Voucher_Founders_Ninja_Weapon_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Outlander_Bundle": {
+      "templateId": "AccountResource:Voucher_Founders_Outlander_Bundle",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Outlander_Weapon_SR": {
+      "templateId": "AccountResource:Voucher_Founders_Outlander_Weapon_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Outlander_Weapon_VR": {
+      "templateId": "AccountResource:Voucher_Founders_Outlander_Weapon_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Soldier_Bundle": {
+      "templateId": "AccountResource:Voucher_Founders_Soldier_Bundle",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Soldier_Weapon_SR": {
+      "templateId": "AccountResource:Voucher_Founders_Soldier_Weapon_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_Soldier_Weapon_VR": {
+      "templateId": "AccountResource:Voucher_Founders_Soldier_Weapon_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Founders_StarterWeapons_Bundle": {
+      "templateId": "AccountResource:Voucher_Founders_StarterWeapons_Bundle",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Defender_R": {
+      "templateId": "AccountResource:Voucher_Generic_Defender_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Defender_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Defender_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Defender_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Defender_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Hero_R": {
+      "templateId": "AccountResource:Voucher_Generic_Hero_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Hero_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Hero_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Hero_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Hero_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Manager_R": {
+      "templateId": "AccountResource:Voucher_Generic_Manager_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Manager_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Manager_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Manager_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Manager_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Melee_R": {
+      "templateId": "AccountResource:Voucher_Generic_Melee_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Melee_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Melee_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Melee_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Melee_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Ranged_R": {
+      "templateId": "AccountResource:Voucher_Generic_Ranged_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Ranged_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Ranged_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Ranged_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Ranged_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Schematic_R": {
+      "templateId": "AccountResource:Voucher_Generic_Schematic_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Schematic_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Schematic_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Schematic_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Schematic_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Trap_R": {
+      "templateId": "AccountResource:Voucher_Generic_Trap_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Trap_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Trap_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Trap_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Trap_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Weapon_R": {
+      "templateId": "AccountResource:Voucher_Generic_Weapon_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Weapon_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Weapon_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Weapon_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Weapon_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Worker_R": {
+      "templateId": "AccountResource:Voucher_Generic_Worker_R",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Worker_SR": {
+      "templateId": "AccountResource:Voucher_Generic_Worker_SR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Generic_Worker_VR": {
+      "templateId": "AccountResource:Voucher_Generic_Worker_VR",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_HeroBuyback": {
+      "templateId": "AccountResource:Voucher_HeroBuyback",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
+    },
+    "AccountResource:Voucher_Item_Buyback": {
+      "templateId": "AccountResource:Voucher_Item_Buyback",
+      "attributes": {
+        "max_level_bonus": 0,
+        "level": 1,
+        "item_seen": true,
+        "xp": 0,
+        "favorite": false
+      },
+      "quantity": 1000000000
     }
   },
   "stats": {
@@ -47519,82 +57428,6 @@
         "CosmeticLocker:cosmeticlocker_stw_1"
       ],
       "collection_book": {
-        "pages": [
-          "CollectionBookPage:pageheroes_ninja",
-          "CollectionBookPage:pageheroes_outlander",
-          "CollectionBookPage:pageheroes_commando",
-          "CollectionBookPage:pageheroes_constructor",
-          "CollectionBookPage:pagepeople_defenders",
-          "CollectionBookPage:pagepeople_leads",
-          "CollectionBookPage:pagepeople_uniqueleads",
-          "CollectionBookPage:pagepeople_survivors",
-          "CollectionBookPage:pageranged_assault_weapons",
-          "CollectionBookPage:pageranged_shotgun_weapons",
-          "CollectionBookPage:page_ranged_pistols_weapons",
-          "CollectionBookPage:pageranged_snipers_weapons",
-          "CollectionBookPage:pageranged_shotgun_weapons_crystal",
-          "CollectionBookPage:pageranged_assault_weapons_crystal",
-          "CollectionBookPage:page_ranged_pistols_weapons_crystal",
-          "CollectionBookPage:pageranged_snipers_weapons_crystal",
-          "CollectionBookPage:pagetraps_wall",
-          "CollectionBookPage:pagetraps_ceiling",
-          "CollectionBookPage:pagetraps_floor",
-          "CollectionBookPage:pagemelee_swords_weapons",
-          "CollectionBookPage:pagemelee_swords_weapons_crystal",
-          "CollectionBookPage:pagemelee_axes_weapons",
-          "CollectionBookPage:pagemelee_axes_weapons_crystal",
-          "CollectionBookPage:pagemelee_scythes_weapons",
-          "CollectionBookPage:pagemelee_scythes_weapons_crystal",
-          "CollectionBookPage:pagemelee_clubs_weapons",
-          "CollectionBookPage:pagemelee_clubs_weapons_crystal",
-          "CollectionBookPage:pagemelee_spears_weapons",
-          "CollectionBookPage:pagemelee_spears_weapons_crystal",
-          "CollectionBookPage:pagemelee_tools_weapons",
-          "CollectionBookPage:pagemelee_tools_weapons_crystal",
-          "CollectionBookPage:pageranged_explosive_weapons",
-          "CollectionBookPage:pagespecial_springiton2018_people",
-          "CollectionBookPage:pagespecial_chinesenewyear2018_heroes",
-          "CollectionBookPage:pagespecial_weapons_chinesenewyear2018",
-          "CollectionBookPage:pagespecial_weapons_crystal_chinesenewyear2018",
-          "CollectionBookPage:pagespecial_stormzonecyber_heroes",
-          "CollectionBookPage:pagespecial_stormzonecyber_ranged",
-          "CollectionBookPage:pagespecial_stormzonecyber_melee",
-          "CollectionBookPage:pagespecial_stormzonecyber_ranged_crystal",
-          "CollectionBookPage:pagespecial_stormzonecyber_melee_crystal",
-          "CollectionBookPage:pagespecial_blockbuster2018_heroes",
-          "CollectionBookPage:pagespecial_blockbuster2018_ranged",
-          "CollectionBookPage:pagespecial_blockbuster2018_ranged_crystal",
-          "CollectionBookPage:pagespecial_roadtrip2018_heroes",
-          "CollectionBookPage:pagespecial_roadtrip2018_weapons",
-          "CollectionBookPage:pagespecial_roadtrip2018_weapons_crystal",
-          "CollectionBookPage:pagespecial_hydraulic",
-          "CollectionBookPage:pagespecial_hydraulic_crystal",
-          "CollectionBookPage:pagespecial_stormzone_heroes",
-          "CollectionBookPage:pagespecial_scavenger",
-          "CollectionBookPage:pagespecial_scavenger_crystal",
-          "CollectionBookPage:pagespecial_scavenger_heroes",
-          "CollectionBookPage:pagespecial_halloween2017_heroes",
-          "CollectionBookPage:pagespecial_halloween2017_workers",
-          "CollectionBookPage:pagespecial_weapons_ranged_stormzone2",
-          "CollectionBookPage:pagespecial_weapons_ranged_stormzone2_crystal",
-          "CollectionBookPage:pagespecial_weapons_melee_stormzone2",
-          "CollectionBookPage:pagespecial_weapons_melee_stormzone2_crystal",
-          "CollectionBookPage:pagespecial_winter2017_heroes",
-          "CollectionBookPage:pagespecial_weapons_ranged_winter2017",
-          "CollectionBookPage:pagespecial_weapons_ranged_winter2017_crystal",
-          "CollectionBookPage:pagespecial_weapons_melee_winter2017",
-          "CollectionBookPage:pagespecial_weapons_melee_winter2017_crystal",
-          "CollectionBookPage:pagespecial_winter2017_weapons",
-          "CollectionBookPage:pagespecial_winter2017_weapons_crystal",
-          "CollectionBookPage:pagespecial_ratrod_weapons",
-          "CollectionBookPage:pagespecial_ratrod_weapons_crystal",
-          "CollectionBookPage:pagespecial_weapons_ranged_medieval",
-          "CollectionBookPage:pagespecial_weapons_ranged_medieval_crystal",
-          "CollectionBookPage:pagespecial_weapons_melee_medieval",
-          "CollectionBookPage:pagespecial_weapons_melee_medieval_crystal",
-          "CollectionBookPage:pagespecial_shadowops_heroes",
-          "CollectionBookPage:pagespecial_wildwest_heroes"
-        ],
         "maxBookXpLevelAchieved": 100
       },
       "mfa_reward_claimed": true,


### PR DESCRIPTION
Added all AccountResources, Storm Shield quests up to Twine SSD 5 (to not hide the storyline pages) and Free Perk Slots to all schematics. Removed collection book pages from here since they were useless.
Changed Heroes outfit and backbling variants to maximum edit style for each of them. Thanks to this, the preview of the heroes is the same as on the versions before the introduction of Battle Royale outfits.